### PR TITLE
NAS-109391 / 21.04 / Add dnsutils package

### DIFF
--- a/conf/build.manifest
+++ b/conf/build.manifest
@@ -108,6 +108,10 @@
 		{
 			"package": "fio",
 			"comment": "requested by sales (NAS-108787)"
+		},
+		{
+			"package": "dnsutils",
+			"comment": "requested by community (NAS-109391)"
 		}
 	],
 	"iso-packages": [


### PR DESCRIPTION
Adds the dnsutils package, as requested in NAS-109391 and  here:
https://www.truenas.com/community/threads/new-suggestion-add-nslookup-and-or-dig.91041/

**Reasoning behind change:**
dnsutils comes in handy when people run into issues with dns and/or networking in general.
Which actually what a significant amount of issues reported on the forums is about.

Signed-off-by: Kjeld Schouten-Lebbing <kjeld@schouten-lebbing.nl>