### PR TITLE
Build with custom kernel

### DIFF
--- a/conf/build.manifest
+++ b/conf/build.manifest
@@ -51,6 +51,9 @@
 	},
 	"base-packages": [
 		"dosfstools",
+		"linux-truenas-libc-dev",
+		"linux-headers-truenas-amd64",
+		"linux-image-truenas-amd64",
 		"consul",
 		"firmware-bnx2",
 		"firmware-bnx2x",
@@ -114,6 +117,8 @@
 	],
 	"iso-packages": [
 		"curl",
+		"bzip2",
+		"linux-image-truenas-amd64",
 		"dialog",
 		"iproute2",
 		"jq",
@@ -127,6 +132,11 @@
 	],
 	"sources": [
 		{
+			"name": "kernel",
+			"repo": "https://github.com/truenas/linux",
+			"branch": "SCALE-v5.10-stable"
+		},
+		{
 			"name": "nfs4xdr_acl_tools",
 			"repo": "https://github.com/truenas/nfs4xdr-acl-tools",
 			"branch": "master"
@@ -134,8 +144,9 @@
 		{
 			"name": "openzfs",
 			"repo": "https://github.com/truenas/zfs",
-			"branch": "truenas/zfs-2.0-release",
+			"branch": "build-with-custom-kernel",
 			"predepscmd": "cp -r contrib/truenas debian",
+			"kernel_module": true,
 			"generate_version": false
 		},
 		{
@@ -180,7 +191,8 @@
 			"name": "scst",
 			"repo": "https://github.com/truenas/scst",
 			"prebuildcmd": "make dpkg DEBEMAIL=no-reply@ixsystems.com DEBFULLNAME=TrueNAS",
-			"branch": "v3.5-branch"
+			"kernel_module": true,
+			"branch": "build-with-truenas-kernel"
 		},
 		{
 			"name": "truenas_binaries",

--- a/conf/build.manifest
+++ b/conf/build.manifest
@@ -144,7 +144,7 @@
 		{
 			"name": "openzfs",
 			"repo": "https://github.com/truenas/zfs",
-			"branch": "build-with-custom-kernel",
+			"branch": "truenas/zfs-2.0-release",
 			"predepscmd": "cp -r contrib/truenas debian",
 			"kernel_module": true,
 			"generate_version": false
@@ -192,7 +192,7 @@
 			"repo": "https://github.com/truenas/scst",
 			"prebuildcmd": "make dpkg DEBEMAIL=no-reply@ixsystems.com DEBFULLNAME=TrueNAS",
 			"kernel_module": true,
-			"branch": "build-with-truenas-kernel"
+			"branch": "v3.5-branch"
 		},
 		{
 			"name": "truenas_binaries",

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -447,7 +447,7 @@ mk_kernoverlay() {
 	mkdir ${KERNWRK}
 	stored_cwd=$(pwd)
 	cp -r ${SOURCES}/kernel/* ${KERNTMP} || exit_err "Failed to copy sources"
-	apt install -y flex bison dwarves libssl-dev > /dev/null
+	apt install -y flex bison dwarves libssl-dev > /dev/null || exit_err "Failed to install kernel build depenencies."
 	cd ${KERNTMP}; make defconfig > /dev/null
 	make syncconfig >/dev/null
 	make archprepare >/dev/null

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -128,10 +128,10 @@ make_bootstrapdir() {
 			;;
 	esac
 
-	# Setup our ramdisk, up to 8G should suffice
+	# Setup our ramdisk, up to 12G should suffice
 	mkdir -p ${TMPFS}
 	if [ $HAS_LOW_RAM -eq 0 ] || [ -z "$UPDATE" ] ; then
-		mount -t tmpfs -o size=8G tmpfs ${TMPFS}
+		mount -t tmpfs -o size=12G tmpfs ${TMPFS}
 	fi
 
 	# Check if we should invalidate the base cache

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -30,6 +30,23 @@ LOG_DIR="./logs"
 HASH_DIR="./tmp/pkghashes"
 MANIFEST="./conf/build.manifest"
 SOURCES="./sources"
+HAS_LOW_RAM=0
+
+# Kernel build variables
+# Config options can be overridden by adding a stub
+# config with kernel parameters to scripts/package/truenas/extra.config
+# in the kernel source directory and uncommenting EXTRA_KERNEL_CONFIG
+# Debug kernel can be built by uncommenting DEBUG_KERNEL
+
+KERNTMP="./tmp/kern"
+KERNWRK="./tmp/kernwrk"
+TN_CONFIG="scripts/package/truenas/tn.config"
+DEBUG_CONFIG="scripts/package/truenas/debug.config"
+EXTRA_CONFIG="scripts/package/truenas/extra.config"
+#DEBUG_KERNEL=1
+#EXTRA_KERNEL_CONFIG=1
+
+#PKG_DEBUG=1
 
 # When loggin in as 'su root' the /sbin dirs get dropped out of PATH
 export PATH="${PATH}:/sbin:/usr/sbin:/usr/local/sbin"
@@ -41,7 +58,11 @@ export LANG="C"
 # Passed along to WAF for parallel build
 export DEB_BUILD_OPTIONS="parallel=$(nproc)"
 
-# Never go full interactive on any packages
+# Build kernel with debug symbols
+export CONFIG_DEBUG_INFO=N
+export CONFIG_LOCALVERSION="+truenas"
+
+# Never go full interactive on any packages#
 export DEBIAN_FRONTEND="noninteractive"
 
 # Source helper functions
@@ -72,6 +93,7 @@ EOF
 }
 
 make_bootstrapdir() {
+	del_kernoverlay
 	del_overlayfs
 	del_bootstrapdir
 
@@ -85,11 +107,19 @@ make_bootstrapdir() {
 			CDBUILD=1
 			DEOPTS="--components=main,contrib,nonfree --variant=minbase --include=systemd-sysv,gnupg"
 			CACHENAME="cdrom"
+			unset UPDATE
+			;;
+		update)
+			UPDATE=1
+			DEOPTS=""
+			CACHENAME="package"
+			unset CDBUILD
 			;;
 		package|packages)
 			DEOPTS=""
 			CACHENAME="package"
 			unset CDBUILD
+			unset UPDATE
 			;;
 		*)
 			exit_err "Invalid bootstrapdir target"
@@ -98,7 +128,9 @@ make_bootstrapdir() {
 
 	# Setup our ramdisk, up to 4G should suffice
 	mkdir -p ${TMPFS}
-	mount -t tmpfs -o size=8G tmpfs ${TMPFS}
+	if [ $HAS_LOW_RAM -eq 0 ] || [ -z "$UPDATE" ] ; then
+		mount -t tmpfs -o size=8G tmpfs ${TMPFS}
+	fi
 
 	# Check if we should invalidate the base cache
 	validate_basecache "$CACHENAME"
@@ -278,10 +310,16 @@ del_bootstrapdir() {
 	umount -f ${CHROOT_BASEDIR}/proc 2>/dev/null
 	umount -f ${CHROOT_BASEDIR}/sys 2>/dev/null
 	umount -f ${CHROOT_BASEDIR} 2>/dev/null
+	umount -f ${CHROOT_BASEDIR}/packages 2>/dev/null
 	umount -Rf ${CHROOT_BASEDIR} 2>/dev/null
 	rmdir ${CHROOT_BASEDIR} 2>/dev/null
 	umount -Rf ${TMPFS} 2>/dev/null
-	rmdir ${TMPFS} 2>/dev/null
+	if [ $HAS_LOW_RAM -eq 1 ] ; then
+		rm -rf ${TMPFS}
+	else
+		umount -Rf ${TMPFS} 2>/dev/null
+		rmdir ${TMPFS} 2>/dev/null
+	fi
 }
 
 del_overlayfs() {
@@ -320,6 +358,7 @@ build_deb_packages() {
 		mkdir -p ${LOG_DIR}/packages
 	fi
 	rm ${LOG_DIR}/packages/* 2>/dev/null
+	mk_kernoverlay
 
 	for k in $(jq -r '."sources" | keys[]' ${MANIFEST} 2>/dev/null | tr -s '\n' ' ')
 	do
@@ -327,13 +366,14 @@ build_deb_packages() {
 		mk_overlayfs
 
 		# Clear variables we are going to load from MANIFEST
-		unset GENERATE_VERSION SUBDIR PREBUILD PREDEP NAME
+		unset GENERATE_VERSION SUBDIR PREBUILD PREDEP NAME KMOD
 
 		NAME=$(jq -r '."sources"['$k']."name"' ${MANIFEST})
 		PREDEP=$(jq -r '."sources"['$k']."predepscmd"' ${MANIFEST})
 		PREBUILD=$(jq -r '."sources"['$k']."prebuildcmd"' ${MANIFEST})
 		SUBDIR=$(jq -r '."sources"['$k']."subdir"' ${MANIFEST})
 		GENERATE_VERSION=$(jq -r '."sources"['$k']."generate_version"' ${MANIFEST})
+		KMOD=$(jq -r '."sources"['$k']."kernel_module"' ${MANIFEST})
 		if [ ! -d "${SOURCES}/${NAME}" ] ; then
 			exit_err "Missing sources for ${NAME}, did you forget to run 'make checkout'?"
 		fi
@@ -358,11 +398,20 @@ build_deb_packages() {
 		clean_previous_packages "$NAME" >${LOG_DIR}/packages/${NAME}.log 2>&1
 
 		# Do the build now
-		if [ -n "${PKG_DEBUG}" ] ; then
-			# Running in PKG_DEBUG mode - Display to stdout
-			build_dpkg "$NAME" "$PREDEP" "$PREBUILD" "$SUBDIR" "$GENERATE_VERSION"
+		if [ "$NAME" = "kernel" ] ; then
+			if [ -n "${PKG_DEBUG}" ] ; then
+				# Running in PKG_DEBUG mode - Display to stdout
+				build_kernel_dpkg "$NAME" "$PREDEP" "$PREBUILD" "$SUBDIR" "$GENERATE_VERSION"
+			else
+				build_kernel_dpkg "$NAME" "$PREDEP" "$PREBUILD" "$SUBDIR" "$GENERATE_VERSION" >>${LOG_DIR}/packages/${NAME}.log 2>&1
+			fi
 		else
-			build_dpkg "$NAME" "$PREDEP" "$PREBUILD" "$SUBDIR" "$GENERATE_VERSION" >>${LOG_DIR}/packages/${NAME}.log 2>&1
+			if [ -n "${PKG_DEBUG}" ] ; then
+				# Running in PKG_DEBUG mode - Display to stdout
+				build_normal_dpkg "$NAME" "$PREDEP" "$PREBUILD" "$SUBDIR" "$GENERATE_VERSION" "$KMOD"
+			else
+				build_normal_dpkg "$NAME" "$PREDEP" "$PREBUILD" "$SUBDIR" "$GENERATE_VERSION" "$KMOD" >>${LOG_DIR}/packages/${NAME}.log 2>&1
+			fi
 		fi
 
 		# Save the build hash
@@ -390,27 +439,83 @@ clean_previous_packages() {
 	rm ${HASH_DIR}/${1}.pkglist
 }
 
-build_dpkg() {
-	if [ -e "${DPKG_OVERLAY}/packages/Packages.gz" ] ; then
-		chroot ${DPKG_OVERLAY} apt update || exit_err "Failed apt update"
+mk_kernoverlay() {
+	# Generate kernel overlay (but not mount).
+	# This makes our debian directory and kernel config used for building
+	# debian folder is required to install pre-build dependencies.
+	mkdir ${KERNTMP}
+	mkdir ${KERNWRK}
+	stored_cwd=$(pwd)
+	cp -r ${SOURCES}/kernel/* ${KERNTMP} || exit_err "Failed to copy sources"
+	apt install -y flex bison dwarves libssl-dev > /dev/null
+	cd ${KERNTMP}; make defconfig > /dev/null
+	make syncconfig >/dev/null
+	make archprepare >/dev/null
+	echo "Merging ${TN_CONFIG} with .config"
+	./scripts/kconfig/merge_config.sh .config ${TN_CONFIG} > /dev/null || exit_err "Failed to merge config"
+	if [ -n "${DEBUG_KERNEL}" ] ; then
+		echo "Merging ${DEBUG_CONFIG} with .config"
+		./scripts/kconfig/merge_config.sh .config ${DEBUG_CONFIG} > /dev/null || exit_err "Failed to merge config"
 	fi
+	if [ -n "${EXTRA_KERNEL_CONFIG}" ] ; then
+		echo "Merging ${EXTRA_CONFIG} with .config"
+		./scripts/kconfig/merge_config.sh .config ${EXTRA_CONFIG} > /dev/null || exit_err "Failed to merge config"
+	fi
+	./scripts/package/mkdebian 2>/dev/null
+	cd "${stored_cwd}"
+}
+
+mount_kern() {
+	# In all cases where package being built is not the kernel itself, our
+	# kernel source is mounted to /kernel so that it's visible to developer
+	# when debugging a package build failure.
+	kdir="$1"
+	if [ -z ${kdir} ]; then
+		kdir="kernel"
+	fi
+	kernlower="${DPKG_OVERLAY}/${kdir}"
+	if [ ! -e "${kernlower}" ]; then
+		mkdir -p "${kernlower}"
+	fi
+	mount -t overlay -o lowerdir="${kernlower}",upperdir="${KERNTMP}",workdir="${KERNWRK}", none "${kernlower}"
+}
+
+umount_kern() {
+	kdir="$1"
+	if [ -z $kdir ]; then
+		kdir="kernel"
+	fi
+        #umount -f "${DPG_OVERLAY}/${kdir}" 2>/dev/null
+        umount -f "${DPKG_OVERLAY}/${kdir}"
+}
+
+del_kernoverlay() {
+	umount_kern
+	rm -rf ${KERNTMP}
+	rm -rf ${KERNWRK}
+}
+
+do_prebuild() {
 	name="$1"
 	predep="$2"
 	prebuild="$3"
 	subarg="$4"
 	generate_version="$5"
-	deflags="-us -uc -b"
+	srcdir="$6"
+	pkgdir="$7"
+	kmod="$8"
 
-	# Check if we have a valid sub directory for these sources
-	if [ -z "$subarg" -o "$subarg" = "null" ] ; then
-		subdir=""
+	if [ "$name" = "kernel" ] ; then
+		mount_kern "dpkg-src"
 	else
-		subdir="/$subarg"
+		mount_kern
+		cp -r ${SOURCES}/${name} ${DPKG_OVERLAY}/dpkg-src || exit_err "Failed to copy sources"
 	fi
-	srcdir="/dpkg-src$subdir"
-	pkgdir="$srcdir/../"
 
-	cp -r ${SOURCES}/${name} ${DPKG_OVERLAY}/dpkg-src || exit_err "Failed to copy sources"
+	if [ "$kmod" = "true" ] ; then
+		chroot ${DPKG_OVERLAY} /bin/bash -c "apt install -y /packages/linux-headers-truenas*"
+		chroot ${DPKG_OVERLAY} /bin/bash -c "apt install -y /packages/linux-image-truenas*"
+	fi
 
 	# Check for a predep command
 	if [ -n "$predep" -a "$predep" != "null" ] ; then
@@ -418,13 +523,20 @@ build_dpkg() {
 		chroot ${DPKG_OVERLAY} /bin/bash -c "cd $srcdir && $predep" || exit_err "Failed to execute predep command"
 	fi
 
+	# Install all the build depends
 	if [ ! -e "${DPKG_OVERLAY}/$srcdir/debian/control" ] ; then
 		exit_err "Missing debian/control file for $name"
 	fi
-
-	# Install all the build depends
 	chroot ${DPKG_OVERLAY} /bin/bash -c "cd $srcdir && mk-build-deps --build-dep" || exit_err "Failed mk-build-deps"
-	chroot ${DPKG_OVERLAY} /bin/bash -c "cd $srcdir && apt install -y ./*.deb" || exit_err "Failed install build deps"
+	chroot ${DPKG_OVERLAY} /bin/bash -c "cd $srcdir && apt install -y ./*.deb"
+	if [ $? -ne 0 ] ; then
+		if [ -n "${PKG_DEBUG}" ] ; then
+			echo "Failed install build deps - Entering debug Shell"
+			chroot ${DPKG_OVERLAY} /bin/bash
+		fi
+		exit_err "Failed install build deps"
+	fi
+
 	if [ $name = truenas ] ; then
 		mkdir ${DPKG_OVERLAY}${srcdir}/data
 		echo '{"buildtime": '$BUILDTIME', "train": "'$TRAIN'", "version": "'$VERSION'"}' > ${DPKG_OVERLAY}${srcdir}/data/manifest.json
@@ -445,7 +557,6 @@ build_dpkg() {
 		fi
 	fi
 
-
 	# Make a programatically generated version for this build
 	if [ "$generate_version" != "false" ] ; then
 		DATESTAMP=$(date +%Y%m%d%H%M%S)
@@ -453,9 +564,89 @@ build_dpkg() {
 	else
 		chroot ${DPKG_OVERLAY} /bin/bash -c "cd $srcdir && dch -b -M --force-distribution --distribution bullseye-truenas-unstable 'Tagged from truenas-build'" || exit_err "Failed dch changelog"
 	fi
+}
 
+build_kernel_dpkg() {
+	if [ -e "${DPKG_OVERLAY}/packages/Packages.gz" ] ; then
+		chroot ${DPKG_OVERLAY} apt update || exit_err "Failed apt update"
+	fi
+	name="$1"
+	predep="$2"
+	prebuild="$3"
+	subarg="$4"
+	generate_version="$5"
+	deflags="-j$(nproc) -us -uc -b"
+
+	# Check if we have a valid sub directory for these sources
+	if [ -z "$subarg" -o "$subarg" = "null" ] ; then
+		subdir=""
+	else
+		subdir="/$subarg"
+	fi
+	srcdir="/dpkg-src$subdir"
+	pkgdir="$srcdir/../"
+	do_prebuild "$name" "$predep" "$prebuild" "$subarg" "$generate_version" "$srcdir" "$pkgdir" "false"
 	# Build the package
 	#chroot ${DPKG_OVERLAY} /bin/bash -c "cd $srcdir && debuild $deflags" || exit_err "Failed to build package"
+	#chroot ${DPKG_OVERLAY} /bin/bash -c "cd $srcdir && debuild $deflags"
+	chroot ${DPKG_OVERLAY} /bin/bash -c "cp ${srcdir}/.config /"
+	chroot ${DPKG_OVERLAY} /bin/bash -c "cd $srcdir && make distclean && cp /.config ${srcdir}/.config"
+	#chroot ${DPKG_OVERLAY} /bin/bash -c "cd $srcdir && ./scripts/kconfig/merge_config.sh .config ${TN_CONFIG}"
+	chroot ${DPKG_OVERLAY} /bin/bash -c "cd $srcdir && make -j6 bindeb-pkg"
+
+        if [ $? -ne 0 ] ; then
+		if [ -n "${PKG_DEBUG}" ] ; then
+			echo "Package build failed - Entering debug Shell"
+			echo "Build Command: cd $srcdir && debuild $deflags"
+			chroot ${DPKG_OVERLAY} /bin/bash
+		fi
+		exit_err "Failed to build packages"
+	fi
+
+	# Move out the resulting packages
+	echo "Copying finished packages"
+
+	# Copy and record each built packages for cleanup later
+	for pkg in $(ls ${DPKG_OVERLAY}${pkgdir}/*.deb ${DPKG_OVERLAY}${pkgdir}/*.udeb 2>/dev/null)
+	do
+		basepkg=$(basename $pkg)
+		mv ${DPKG_OVERLAY}${pkgdir}/$basepkg ${PKG_DIR}/ || exit_err "Failed mv of $basepkg"
+		echo "$basepkg" >>${HASH_DIR}/${NAME}.pkglist || "Failed recording package name(s)"
+	done
+	mv ${DPKG_OVERLAY}${pkgdir}/*.deb ${PKG_DIR}/ 2>/dev/null
+	mv ${DPKG_OVERLAY}${pkgdir}/*.udeb ${PKG_DIR}/ 2>/dev/null
+
+	# Update the local APT repo
+	echo "Building local APT repo Packages.gz..."
+	chroot ${DPKG_OVERLAY} /bin/bash -c 'cd /packages && dpkg-scanpackages . /dev/null | gzip -9c > Packages.gz'
+	umount_kern "dpkg-src"
+}
+
+build_normal_dpkg() {
+	if [ -e "${DPKG_OVERLAY}/packages/Packages.gz" ] ; then
+		chroot ${DPKG_OVERLAY} apt update || exit_err "Failed apt update"
+	fi
+	name="$1"
+	predep="$2"
+	prebuild="$3"
+	subarg="$4"
+	generate_version="$5"
+	kmod="$6"
+	deflags="-j$(nproc) -us -uc -b"
+
+	# Check if we have a valid sub directory for these sources
+	if [ -z "$subarg" -o "$subarg" = "null" ] ; then
+		subdir=""
+	else
+		subdir="/$subarg"
+	fi
+	srcdir="/dpkg-src$subdir"
+	pkgdir="$srcdir/../"
+
+	do_prebuild "$name" "$predep" "$prebuild" "$subarg" "$generate_version" "$srcdir" "$pkgdir" "$kmod"
+	# Build the package
+	#chroot ${DPKG_OVERLAY} /bin/bash -c "cd $srcdir && debuild $deflags" || exit_err "Failed to build package"
+	#chroot ${DPKG_OVERLAY} /bin/bash -c "cd $srcdir && debuild $deflags"
 	chroot ${DPKG_OVERLAY} /bin/bash -c "cd $srcdir && debuild $deflags"
         if [ $? -ne 0 ] ; then
 		if [ -n "${PKG_DEBUG}" ] ; then
@@ -463,6 +654,7 @@ build_dpkg() {
 			echo "Build Command: cd $srcdir && debuild $deflags"
 			chroot ${DPKG_OVERLAY} /bin/bash
 		fi
+		umount_kern
 		exit_err "Failed to build packages"
 	fi
 
@@ -685,6 +877,7 @@ install_rootfs_packages() {
 	mkdir -p ${CHROOT_BASEDIR}/packages
 
 	mount --bind ${PKG_DIR} ${CHROOT_BASEDIR}/packages || exit_err "Failed mount --bind /packages"
+	echo "force-unsafe-io" > ${CHROOT_BASEDIR}/etc/dpkg/dpkg.cfg.d/force-unsafe-io || exit_err "Failed to force unsafe io"
 	chroot ${CHROOT_BASEDIR} apt update || exit_err "Failed apt update"
 
 	for package in $(jq -r '."base-packages" | values[]' $MANIFEST | tr -s '\n' ' ')
@@ -716,6 +909,7 @@ install_rootfs_packages() {
 	cp conf/sources.list ${CHROOT_BASEDIR}/etc/apt/sources.list || exit_err "Failed installing sources.list"
 
 	#chroot ${CHROOT_BASEDIR} /bin/bash
+	chroot ${CHROOT_BASEDIR} depmod
 	umount -f ${CHROOT_BASEDIR}/packages
 	rmdir ${CHROOT_BASEDIR}/packages
 	umount -f ${CHROOT_BASEDIR}/proc
@@ -747,7 +941,6 @@ clean_rootfs() {
 	rm -rf ${CHROOT_BASEDIR}/var/cache/apt/*
 	rm -rf ${CHROOT_BASEDIR}/var/lib/apt/lists/*
 }
-
 
 custom_rootfs_setup() {
 
@@ -837,7 +1030,7 @@ build_manifest() {
 build_update_image() {
 	rm ${LOG_DIR}/rootfs* 2>/dev/null
 	echo "`date`: Bootstrapping TrueNAS rootfs [UPDATE] (${LOG_DIR}/rootfs-bootstrap.log)"
-	make_bootstrapdir "package" >${LOG_DIR}/rootfs-bootstrap.log 2>&1
+	make_bootstrapdir "update" >${LOG_DIR}/rootfs-bootstrap.log 2>&1
 	echo "`date`: Installing TrueNAS rootfs packages [UPDATE] (${LOG_DIR}/rootfs-packages.log)"
 	install_rootfs_packages >${LOG_DIR}/rootfs-packages.log 2>&1
 	echo "`date`: Building TrueNAS rootfs image [UPDATE] (${LOG_DIR}/rootfs-image.log)"

--- a/scripts/functions.sh
+++ b/scripts/functions.sh
@@ -35,6 +35,7 @@ preflight_check() {
 	local mem=$(grep MemTotal /proc/meminfo | awk -F ' ' '{print $2}')
 	if [ $mem -lt 15500000 ] ; then
 		echo "WARNING: Running with less than 16GB of memory. Build may fail..."
+		HAS_LOW_RAM=1
 		sleep 5
 	fi
 


### PR DESCRIPTION
This adds linux kernel to the build. Due to size of repo and temporary files,
logic for building kernel is slightly different than other packages. A non-tmpfs
filesystem is overlaid as dpkg-src in this case and build on it rather than tmpfs.

Kernel config is generated in two or three steps during the build process.
make defconfig is run to generate a default config based on architecture, then
the TrueNAS-specific configuration is merged with it, and if a debug kernel is
requested (by uncommenting relevent line in build.sh), additional debugging parameters
are applied.

A customized copy of current kernel source is also mounted as /kernel inside the
package build chroot. A new key has also been added to the build_manifest "kernel_module",
which if set to true will cause the kernel image and headers to be installed in the
package building chroot prior to fulfilling the packages dependencies.

A minor change to behavior in low ram situations (i.e. less than recommended amount) was
added to the effect that update files will not be generated on tmpfs. In testing this
stage of the overall build process was obvserved to be most likely to fail due to running
out of space on the tmpfs filesystem.