### PR TITLE
Bump build epoch to force a clean rebuild

### DIFF
--- a/conf/build.manifest
+++ b/conf/build.manifest
@@ -93,7 +93,7 @@
 		"libgdk-pixbuf2.0-0",
 		"x11-common"
 	],
-	"build-epoch":1,
+	"build-epoch": 2,
 	"additional-packages": [
 		{
 			"package": "xtail",


### PR DESCRIPTION
After openzfs changes, we would like to have a clean rebuild of packages dependent on openzfs, bumping build-epoch will have the desired affect.