### PR TITLE
NAS-110344 / 21.06 / add nvme-cli to base packages

### DIFF
--- a/conf/build.manifest
+++ b/conf/build.manifest
@@ -82,6 +82,7 @@ base-packages:
 - wireguard-tools
 - zfs-test
 - zfs-initramfs
+- nvme-cli
 
 #
 # Packages which are removed from the base TrueNAS SCALE System by default


### PR DESCRIPTION
Adding to base packages since this tool will be used heavily when NVMe "functionality" is added to SCALE Enterprise.