### PR TITLE
Remove python3-aiohttp from build manifest

### DIFF
--- a/conf/build.manifest
+++ b/conf/build.manifest
@@ -338,9 +338,6 @@ sources:
 - name: swagger
   repo: https://github.com/truenas/swagger
   branch: main
-- name: python_aiohttp
-  repo: https://github.com/truenas/python-aiohttp
-  branch: debian/3.7.3-1
 - name: truenas_files
   repo: https://github.com/truenas/freenas
   branch: master


### PR DESCRIPTION
This commit adds changes to remove python3-aiohttp remove from build manifest as we have an updated version available upstream now which was not the case when it was added to build.