### PR TITLE
NAS-110812 / 21.08 / Restart truenas-install on failure

### DIFF
--- a/conf/cd-files/root/.bash_profile
+++ b/conf/cd-files/root/.bash_profile
@@ -4,4 +4,4 @@
 mkdir /cdrom
 mount /dev/disk/by-label/ISOIMAGE /cdrom
 
-/sbin/truenas-install
+until /sbin/truenas-install; do true; done


### PR DESCRIPTION
The install script exits with an error when the user cancels.  We should
restart the installer rather than dropping to a shell.