### PR TITLE
NAS-110934 / 21.08 / Allow specifying environment variables independently

### DIFF
--- a/conf/build.manifest
+++ b/conf/build.manifest
@@ -181,6 +181,9 @@ sources:
   repo: https://github.com/truenas/linux
   branch: SCALE-v5.10-stable
   batch_priority: 0
+  env:
+    CONFIG_DEBUG_INFO: "Y"
+    CONFIG_LOCALVERSION: "+truenas"
   predepscmd:
     - "apt install -y flex bison dwarves libssl-dev"
     # We remove git files because kernel makefile tries to interact with git for determining version

--- a/scale_build/packages/build.py
+++ b/scale_build/packages/build.py
@@ -19,8 +19,7 @@ class BuildPackageMixin:
             env={
                 **os.environ,
                 **APT_ENV,
-                'CONFIG_DEBUG_INFO': 'Y',  # Build kernel with debug symbols
-                'CONFIG_LOCALVERSION': '+truenas',
+                **self.env,
             }
         )
 
@@ -71,7 +70,7 @@ class BuildPackageMixin:
                 predep_cmd = predep_entry['command']
                 skip_cmd = False
                 for env_var in predep_entry['env_checks']:
-                    if os.environ.get(env_var['key']) != env_var['value']:
+                    if all(f(env_var['key']) != env_var['value'] for f in (os.environ.get, self.env.get)):
                         self.logger.debug(
                             'Skipping %r predep command because %r does not match %r',
                             predep_cmd, env_var['key'], env_var['value']

--- a/scale_build/packages/build.py
+++ b/scale_build/packages/build.py
@@ -16,11 +16,7 @@ class BuildPackageMixin:
     def run_in_chroot(self, command, exception_message=None):
         run(
             f'chroot {self.dpkg_overlay} /bin/bash -c "{command}"', shell=True, exception_msg=exception_message,
-            env={
-                **os.environ,
-                **APT_ENV,
-                **self.env,
-            }
+            env=self._get_build_env()
         )
 
     @property
@@ -55,6 +51,13 @@ class BuildPackageMixin:
         self.clean_previous_packages()
         self._build_impl()
 
+    def _get_build_env(self):
+        return {
+            **os.environ,
+            **APT_ENV,
+            **self.env,
+        }
+
     def _build_impl(self):
         shutil.copytree(self.source_path, self.source_in_chroot, dirs_exist_ok=True, symlinks=True)
         if os.path.exists(os.path.join(self.dpkg_overlay_packages_path, 'Packages.gz')):
@@ -69,8 +72,9 @@ class BuildPackageMixin:
             if isinstance(predep_entry, dict):
                 predep_cmd = predep_entry['command']
                 skip_cmd = False
+                build_env = self._get_build_env()
                 for env_var in predep_entry['env_checks']:
-                    if all(f(env_var['key']) != env_var['value'] for f in (os.environ.get, self.env.get)):
+                    if build_env.get(env_var['key']) != env_var['value']:
                         self.logger.debug(
                             'Skipping %r predep command because %r does not match %r',
                             predep_cmd, env_var['key'], env_var['value']

--- a/scale_build/packages/package.py
+++ b/scale_build/packages/package.py
@@ -26,7 +26,7 @@ class Package(BootstrapMixin, BuildPackageMixin, BuildCleanMixin, OverlayMixin):
     def __init__(
         self, name, branch, repo, prebuildcmd=None, kernel_module=False, explicit_deps=None,
         generate_version=True, predepscmd=None, deps_path=None, subdir=None, deoptions=None, jobs=None,
-        buildcmd=None, tmpfs=True, tmpfs_size=12, batch_priority=100
+        buildcmd=None, tmpfs=True, tmpfs_size=12, batch_priority=100, env=None,
     ):
         self.name = name
         self.branch = branch
@@ -53,6 +53,7 @@ class Package(BootstrapMixin, BuildPackageMixin, BuildCleanMixin, OverlayMixin):
         self.logger = logger
         self.children = set()
         self.batch_priority = batch_priority
+        self.env = env or {}
 
     def __eq__(self, other):
         return other == self.name if isinstance(other, str) else self.name == other.name


### PR DESCRIPTION
This commit adds changes to allow specifying enviornment variables independently for each package. This is helpful to avoid influence of one env variable meant for a specific package on another which might result in changed behavior when it builds.