### PR TITLE
NAS-110826 / 21.08 / Build inadyn from source

### DIFF
--- a/conf/build.manifest
+++ b/conf/build.manifest
@@ -181,7 +181,7 @@ sources:
   repo: https://github.com/truenas/openseachest
 - name: inadyn
   branch: master
-  repo: https://github.com/troglobit/inadyn.git
+  repo: https://github.com/truenas/inadyn.git
 - name: kernel
   repo: https://github.com/truenas/linux
   branch: SCALE-v5.10-stable

--- a/conf/build.manifest
+++ b/conf/build.manifest
@@ -177,6 +177,9 @@ sources:
 - name: openseachest
   branch: truenas/master
   repo: https://github.com/truenas/openseachest
+- name: inadyn
+  branch: master
+  repo: https://github.com/troglobit/inadyn.git
 - name: kernel
   repo: https://github.com/truenas/linux
   branch: SCALE-v5.10-stable

--- a/conf/build.manifest
+++ b/conf/build.manifest
@@ -125,7 +125,9 @@ apt_preferences:
 - Package: "*zfs*"
   Pin: "version 2.1.*"
   Pin-Priority: 1000
-
+- Package: "*inadyn*"
+  Pin: "origin \"\""
+  Pin-Priority: 1000
 #
 # List of additional packages installed into TrueNAS SCALE, along with link
 # to the ticket specifying the reason for requesting


### PR DESCRIPTION
This PR adds changes to build inadyn from source as the package has not been maintained since mid 2010s in debian repository and we are outdated.