### PR TITLE
NAS-111358 / 21.08 / remove python-is-python2 package

### DIFF
--- a/conf/build.manifest
+++ b/conf/build.manifest
@@ -98,6 +98,7 @@ base-prune:
 - gstreamer1.0-libav
 - libgdk-pixbuf2.0-0
 - x11-common
+- python-is-python2
 
 #
 # Update build-epoch when you want to force the next build to be
@@ -146,6 +147,8 @@ additional-packages:
   comment: requested by performance team (NAS-106154)
 - package: cxgbtool
   comment: requested by OS team (NAS-111041)
+- package: python-is-python3
+  comment: NAS-111358 (symlinks /usr/bin/python to python3)
 
 #
 # List of additional packages installed into TrueNAS SCALE ISO file


### PR DESCRIPTION
`python2` is being installed on SCALE by upstream Debian. See https://packages.debian.org/sid/main/python-is-python2 for details. We already ensure all the dependent ports (and the ones we write) use python3 so no need to keep this around.

However, I'm explicitly installing the `python-is-python3` package since it, literally, only creates a symlink to `/bin/python`. It would be incredibly time consuming to track every single 3rd party package/script  that references the `python` binary file so this should keep the unforeseen fall-out minimal.