### PR TITLE
NAS-110816 / 21.08 / Set bootloader property so zectl can update grub

### DIFF
--- a/truenas_install/__main__.py
+++ b/truenas_install/__main__.py
@@ -166,6 +166,15 @@ def install_grub_freebsd(input, manifest, pool_name, dataset_name, disks):
                 run_command(["umount", "/boot/efi"])
 
 
+def configure_system_for_zectl(boot_pool):
+    root_ds = os.path.join(boot_pool, "ROOT")
+    set_prop = IS_FREEBSD or run_command([
+        "zfs", "get", "-H", "-o", "value", "org.zectl:bootloader", root_ds
+    ]).stdout.strip() != 'grub'
+    if set_prop:
+        run_command(["zfs", "set", "org.zectl:bootloader=grub", root_ds])
+
+
 def main():
     global is_json_output
 
@@ -410,6 +419,8 @@ def main():
         if cleanup:
             run_command(["zfs", "destroy", dataset_name])
         raise
+
+    configure_system_for_zectl(pool_name)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
This commit adds changes to ensure bootloader property is set for BE's so that zectl is able to consume our grub plugin to update grub after making changes to boot environments.