### PR TITLE
NAS-111865 / 21.10 / update scst and fix the build

### DIFF
--- a/conf/build.manifest
+++ b/conf/build.manifest
@@ -258,10 +258,14 @@ sources:
   branch: master
 - name: scst
   repo: https://github.com/truenas/scst
+  generate_version: false
   prebuildcmd:
+    - "make debian/changelog"
+  buildcmd:
+    - "make scst-dist-gzip"
     - "make dpkg DEBEMAIL=no-reply@ixsystems.com DEBFULLNAME=TrueNAS"
   kernel_module: true
-  branch: v3.5-branch
+  branch: truenas-svn-trunk
   explicit_deps:
     - openzfs
 - name: truenas_binaries


### PR DESCRIPTION
Fix multiple problems:

1. `make dpkg` was being run as a `prebuildcmd` but that command actually built the package. So in `_build_impl()` we ran `debuild` which also builds the packages after any `prebuildcmd`. This means we were building `scst` twice...
2. Upstream has fixed multiple issues with the debian packaging, so take advantage of those  fixes
3. I've condensed the divergence from upstream to only making minor modifications to `scst/Makefile`.
4. Finally, `truenas-svn-trunk` is rebased on latest upstream `svn-trunk` which brings in a fix where `zvol` resize was not working without manually restarting the service.