### PR TITLE
NAS-113855 / 22.02 / add zstd to SCALE

### DIFF
--- a/conf/build.manifest
+++ b/conf/build.manifest
@@ -167,6 +167,8 @@ additional-packages:
   comment: NAS-111358 (symlinks /usr/bin/python to python3)
 - package: python3-pip
   comment: NAS-112161 ( requested by QE team )
+- package: zstd
+  comment: NAS-113855 ( requested by engineering team )
 
 #
 # List of additional packages installed into TrueNAS SCALE ISO file


### PR DESCRIPTION
`zstd` brings in `unzstd` which allows uncompressing core dump files on SCALE (they're compressed using zstd algorithm by default).