### PR TITLE
Have waagent install as a dep for truenas

### DIFF
--- a/conf/build.manifest
+++ b/conf/build.manifest
@@ -78,7 +78,6 @@ base-packages:
 - sysstat
 - truecommand-stats
 - truenas
-- waagent
 - wireguard-dkms
 - wireguard-tools
 - zfs-test


### PR DESCRIPTION
We want to install waagent before truenas as waagent is not disabled otherwise because it's not installed at the time. So we will be adding waagent as a dependency for truenas.