### PR TITLE
Add nfs4-acl-tools to the base install

### DIFF
--- a/conf/build.manifest
+++ b/conf/build.manifest
@@ -74,6 +74,7 @@ base-packages:
 - linux-cpupower
 - truenas-samba
 - nfs4xdr-acl-tools
+- nfs4-acl-tools
 - qemu-guest-agent
 - squashfs-tools
 - sysstat


### PR DESCRIPTION
This is primarily intended for use on regression tests through
local NFS mounts, but may also be of some use to support or
sys admins.