### PR TITLE
Add debian-security to builder

### DIFF
--- a/conf/build.manifest
+++ b/conf/build.manifest
@@ -35,6 +35,9 @@ apt-repos:
     distribution: all
     component: main
     key: keys/helm.gpg
+  - url: http://apt.tn.ixsystems.com/apt-direct/angelfish/nightlies/debian-security/
+    distribution: bullseye-security
+    components: main non-free contrib
 
 #
 # Packages which are installed into the base TrueNAS SCALE System by default

--- a/conf/build.manifest
+++ b/conf/build.manifest
@@ -150,6 +150,9 @@ apt_preferences:
 - Package: "*ssl*"
   Pin: "release n=bullseye-security"
   Pin-Priority: 1000
+- Package: "*policykit*"
+  Pin: "release n=bullseye-security"
+  Pin-Priority: 1000
 #
 # List of additional packages installed into TrueNAS SCALE, along with link
 # to the ticket specifying the reason for requesting

--- a/conf/sources.list
+++ b/conf/sources.list
@@ -6,4 +6,5 @@ deb http://apt.tn.ixsystems.com/apt-direct/angelfish/nightlies/nvidia-container/
 deb http://apt.tn.ixsystems.com/apt-direct/angelfish/nightlies/nvidia-docker/ bullseye main
 deb http://apt.tn.ixsystems.com/apt-direct/angelfish/nightlies/debian/ bullseye main
 deb http://apt.tn.ixsystems.com/apt-direct/angelfish/nightlies/debian-debug/ bullseye-debug main
+deb http://apt.tn.ixsystems.com/apt-direct/angelfish/nightlies/debian-security/ bullseye-security main
 deb http://apt.tn.ixsystems.com/apt-direct/angelfish/nightlies/helm/ all main

--- a/scale_build/bootstrap/bootstrapdir.py
+++ b/scale_build/bootstrap/bootstrapdir.py
@@ -52,13 +52,6 @@ class BootstrapDir(CacheMixin, HashMixin):
         with open(os.path.join(apt_path, 'preferences'), 'w') as f:
             f.write(get_apt_preferences())
 
-        self.logger.debug('Adding debian-security to sources')
-        deb_security = '\n'.join([
-            'deb http://deb.debian.org/debian-security/ bullseye-security main',
-            'deb-src http://deb.debian.org/debian-security/ bullseye-security main',
-        ])
-        with open(apt_sources_path, 'a+') as f:
-            f.write(f'\n{deb_security}\n')
         run(['chroot', self.chroot_basedir, 'apt', 'update'])
 
         if self.extra_packages_to_install:


### PR DESCRIPTION
This PR introduces following changes:

1. Use our debian mirror instead of upstream debian-security mirror
2. Pull policykit from debian-security mirror instead of debian mirror