### PR TITLE
NAS-114910 / 22.02.1 / Remove contrib/non-free components

### DIFF
--- a/conf/build.manifest
+++ b/conf/build.manifest
@@ -9,7 +9,7 @@ debian_release: "bullseye"
 apt-repos:
   url: http://apt.tn.ixsystems.com/apt-direct/angelfish/nightlies/debian/
   distribution: bullseye
-  components: main non-free contrib
+  components: main
   additional:
   - url: http://apt.tn.ixsystems.com/apt-direct/angelfish/nightlies/docker/
     distribution: buster


### PR DESCRIPTION
This commit adds changes to remove broken contrib/non-free components as they do not exist in the mirror we host and from what i have seen so far they are not used/required either.