### PR TITLE
NAS-115010 / 22.02 / Disable docker-compose

### DIFF
--- a/scale_build/image/update.py
+++ b/scale_build/image/update.py
@@ -102,8 +102,9 @@ def post_rootfs_setup():
         os.chmod(binary_path, stat.S_IMODE(os.lstat(binary_path).st_mode) & no_executable_flag)
     # We want to disable the docker-compose binary so that users want get confused about it
     # not working correctly on SCALE and push them to use other alternatives like Apps, VM or docker-in-docker
-    binary_path = os.path.join(binaries_path, "docker-compose")
-    os.chmod(binary_path, stat.S_IMODE(os.lstat(binary_path).st_mode) & no_executable_flag)
+    ## Please note that this binary is present in two locations and both need to be disabled for correct results.
+    os.chmod(binary_path, stat.S_IMODE(os.lstat("/usr/bin/docker-compose").st_mode) & no_executable_flag)
+    os.chmod(binary_path, stat.S_IMODE(os.lstat("/bin/docker-compose").st_mode) & no_executable_flag)
 
 def custom_rootfs_setup():
     # Any kind of custom mangling of the built rootfs image can exist here

--- a/scale_build/image/update.py
+++ b/scale_build/image/update.py
@@ -100,7 +100,10 @@ def post_rootfs_setup():
     for binary in filter(lambda s: s == 'apt' or s.startswith('apt-'), os.listdir(binaries_path)):
         binary_path = os.path.join(binaries_path, binary)
         os.chmod(binary_path, stat.S_IMODE(os.lstat(binary_path).st_mode) & no_executable_flag)
-
+    # We want to disable the docker-compose binary so that users want get confused about it
+    # not working correctly on SCALE and push them to use other alternatives like Apps, VM or docker-in-docker
+    binary_path = os.path.join(binaries_path, "docker-compose")
+    os.chmod(binary_path, stat.S_IMODE(os.lstat(binary_path).st_mode) & no_executable_flag)
 
 def custom_rootfs_setup():
     # Any kind of custom mangling of the built rootfs image can exist here


### PR DESCRIPTION
Currently the docker-compose binary is enabled. combined with current and previous press releases about 'docker support', this leads to many confused and disappointed users when it doesn't work correctly.

Leading to some users modifying the host system, breaking the Apps system completely. As fixing the issues with docker-compose, inherently breaks (or can break) some of the k3s systems.

There are alternatives available to the user however:
- Using a VM with Linux
- Using/building Apps
- Using Launch Docker
- Using Docker-in-Docker as used in the current proof-of-concept by TrueCharts:
https://truecharts.org/apps/dev/docker-compose/ 


Hence it's time to disable the binary by default, to make clear it's not an included feature of TrueNAS SCALE, while still allowing advanced users to enable it on purpose.

To be clear: Docker-Compose is not a vital component of docker itself and is not used by any of the TrueNAS SCALE subsystems directly. This is already tested locally with good results as well