### PR TITLE
NAS-113898 / 22.02 / Add PowerTop to SCALE (by Ornias1993)

### DIFF
--- a/conf/build.manifest
+++ b/conf/build.manifest
@@ -184,6 +184,8 @@ additional-packages:
   comment: NAS-113855 ( requested by engineering team )
 - package: sdparm
   comment: NAS-114723
+- package: powertop
+  comment: requested by community (NAS-113898)
 
 #
 # List of additional packages installed into TrueNAS SCALE ISO file


### PR DESCRIPTION
Automatic cherry-pick failed. Please resolve conflicts by running:

    git reset --hard HEAD~1
    git cherry-pick -x b9f9cfd25c7df862f08b30a39ab263e8e5e27792
    git cherry-pick -x 6eaacb40ba19d63e0d6490c61e2db49c5fd5f4b0

Powertop is a vital Intel-provided tool for monitoring per-process powerconsumption on power-efficiency focussed systems.
It also allows access to some intel-adviced optimalisations, which is, ofcoarse, not actively supported.

Ofcoarse it does not enable any running-by-default services and also does not make any system changes by default either. Unless manually enabled by the user to do so.

It has to be noted that users of more power-optimised NAS systems are one of the side audiences that SCALE appeals to (as the linux kernel is generally more power efficient), adding this also caters to said audience.

**Testing**
I've manually installed powertop and verified it to be working.
As a precautionary test I also tried to auto-optimise feature on a fujitsu/kontron motherboard with intel i7-9700, to ensure it does not inherently cause damage and/or stability issues to the system. No issues where noticed.

Original PR: https://github.com/truenas/scale-build/pull/206
Jira URL: https://jira.ixsystems.com/browse/NAS-113898