### PR TITLE
NAS-114235 / 22.02.2 / Better Linux kernel configuration procedure

### DIFF
--- a/conf/build.manifest
+++ b/conf/build.manifest
@@ -241,9 +241,8 @@ sources:
     # which results in misconfigured version due to our debian based changes
     - "rm -rf .git .gitattributes .gitignore"
     - "make defconfig"
-    - "make syncconfig"
-    - "make archprepare"
-    - "./scripts/kconfig/merge_config.sh .config scripts/package/truenas/tn.config"
+    - "./scripts/kconfig/merge_config.sh .config scripts/package/truenas/debian_amd64.config"
+    - "./scripts/kconfig/merge_config.sh .config scripts/package/truenas/truenas.config"
     - env_checks:
         - key: DEBUG_KERNEL
           value: true
@@ -252,6 +251,8 @@ sources:
         - key: EXTRA_KERNEL_CONFIG
           value: true
       command: "./scripts/kconfig/merge_config.sh .config scripts/package/truenas/extra.config"
+    - "make syncconfig"
+    - "make archprepare"
     - "./scripts/package/mkdebian"
   buildcmd:
     - "cp -a .config /"


### PR DESCRIPTION
Previously for TrueNAS, Debian Linux kernel configuration was used and
TrueNAS config options were added on top of that. Because of that,
TrueNAS kernel config in 'scripts/package/truenas/tn.config' has grown
very large and difficult to manage for TrueNAS only options.

Debian Linux kernel configuration for version 5.10.92 has been added
as 'debian_amd64.config' to keep the options from Debian seperate from
TrueNAS options. TrueNAS only config options are stored in
'truenas.config'.

Signed-off-by: Umer Saleem <usaleem@ixsystems.com>