### PR TITLE
NAS-115391 / 22.12 / Add apt mirrors before fetching packages

### DIFF
--- a/scale_build/bootstrap/bootstrapdir.py
+++ b/scale_build/bootstrap/bootstrapdir.py
@@ -53,13 +53,8 @@ class BootstrapDir(CacheMixin, HashMixin):
             f.write(get_apt_preferences())
 
         run(['chroot', self.chroot_basedir, 'apt', 'update'])
-
-        if self.extra_packages_to_install:
-            run(['chroot', self.chroot_basedir, 'apt', 'install', '-y'] + self.extra_packages_to_install)
-
-        installed_packages = self.get_packages()
-
-        self.after_extra_packages_installation_steps()
+        # We need to have gnupg installed before adding apt mirrors because apt-key needs it
+        run(['chroot', self.chroot_basedir, 'apt', 'install', '-y', 'gnupg'])
 
         # Save the correct repo in sources.list
         apt_sources = [f'deb {apt_repos["url"]} {apt_repos["distribution"]} {apt_repos["components"]}']
@@ -79,6 +74,13 @@ class BootstrapDir(CacheMixin, HashMixin):
 
         # Update apt
         run(['chroot', self.chroot_basedir, 'apt', 'update'])
+
+        if self.extra_packages_to_install:
+            run(['chroot', self.chroot_basedir, 'apt', 'install', '-y'] + self.extra_packages_to_install)
+
+        installed_packages = self.get_packages()
+
+        self.after_extra_packages_installation_steps()
 
         # Put our local package up at the top of the food chain
         apt_sources.insert(0, 'deb [trusted=yes] file:/packages /')


### PR DESCRIPTION
This commit fixes an issue where we were not adding our custom apt mirrors before installing some basic packages like build-essential etc. Problem was that these packages pull in packages like openssl which we want to pull from specific apt mirror based on our apt preferences rather then using whatever is being provided with the default apt mirrors from debootstrap.