### PR TITLE
Switch angelfish back to building from SCALE-v4-15-stable

### DIFF
--- a/conf/build.manifest
+++ b/conf/build.manifest
@@ -272,7 +272,7 @@ sources:
   generate_version: false
 - name: truenas_samba
   repo: https://github.com/truenas/samba
-  branch: stable/angelfish
+  branch: SCALE-v4-15-stable
   generate_version: false
   batch_priority: 0
   explicit_deps:


### PR DESCRIPTION
I will soon have SCALE-v4-16-stable ready for BlueFin. We don't
need extra branches being maintained for angelfish.

TrueNAS 13 / SCALE Angelfish are based on SCALE-v4-15-stable.