### PR TITLE
NAS-115468 / 22.02.1 / parallelize the git checkout of repo sources (by yocalebo)

### DIFF
--- a/scale_build/checkout.py
+++ b/scale_build/checkout.py
@@ -1,16 +1,37 @@
 import logging
+from concurrent.futures import ThreadPoolExecutor, as_completed
 
 from .utils.git_utils import retrieve_git_remote_and_sha, update_git_manifest
 from .utils.package import get_packages
 
 
 logger = logging.getLogger(__name__)
+MAX_THREADS = 10  # number of threads to spin up to checkout/pull github sources
 
 
 def checkout_sources():
     info = retrieve_git_remote_and_sha('.')
     update_git_manifest(info['url'], info['sha'], 'w')
-    logger.info('Starting checkout of source')
 
-    for package in get_packages():
-        package.checkout(package.get_branch_override())
+    pkgs = {
+        pkg.pkg_name: {
+            'checkout_method': pkg.checkout,
+            'get_branch_override_method': pkg.get_branch_override,
+            'branch_override': None,
+        } for pkg in get_packages()
+    }
+    with ThreadPoolExecutor(max_workers=MAX_THREADS) as exc:
+        logger.info('Getting override for branches')
+        branchoverrides_to_pkgs = {exc.submit(v['get_branch_override_method']): k for k, v in pkgs.items()}
+        for fut in as_completed(branchoverrides_to_pkgs):
+            pkg_name = branchoverrides_to_pkgs[fut]
+            try:
+                branch_override = fut.result()
+            except Exception:
+                logger.warning('Failed to generate branch override for %r', pkg_name, exc_info=True)
+                branch_override = None
+
+            pkgs[pkg_name]['branch_override'] = branch_override
+
+        logger.info('Starting checkout of sources')
+        [exc.submit(v['checkout_method'], v['branch_override']) for pkg, v in pkgs.items()]

--- a/scale_build/checkout.py
+++ b/scale_build/checkout.py
@@ -1,5 +1,5 @@
 import logging
-from concurrent.futures import ThreadPoolExecutor, as_completed
+import concurrent.futures
 
 from .utils.git_utils import retrieve_git_remote_and_sha, update_git_manifest
 from .utils.package import get_packages
@@ -14,24 +14,23 @@ def checkout_sources():
     update_git_manifest(info['url'], info['sha'], 'w')
 
     pkgs = {
-        pkg.pkg_name: {
+        pkg.name: {
             'checkout_method': pkg.checkout,
             'get_branch_override_method': pkg.get_branch_override,
             'branch_override': None,
         } for pkg in get_packages()
     }
-    with ThreadPoolExecutor(max_workers=MAX_THREADS) as exc:
+    with concurrent.futures.ThreadPoolExecutor(max_workers=MAX_THREADS) as exc:
         logger.info('Getting override for branches')
         branchoverrides_to_pkgs = {exc.submit(v['get_branch_override_method']): k for k, v in pkgs.items()}
-        for fut in as_completed(branchoverrides_to_pkgs):
+        for fut in concurrent.futures.as_completed(branchoverrides_to_pkgs):
             pkg_name = branchoverrides_to_pkgs[fut]
             try:
-                branch_override = fut.result()
+                pkgs[pkg_name]['branch_override'] = fut.result()
             except Exception:
                 logger.warning('Failed to generate branch override for %r', pkg_name, exc_info=True)
-                branch_override = None
-
-            pkgs[pkg_name]['branch_override'] = branch_override
+                raise
 
         logger.info('Starting checkout of sources')
-        [exc.submit(v['checkout_method'], v['branch_override']) for pkg, v in pkgs.items()]
+        futures = [exc.submit(v['checkout_method'], v['branch_override']) for pkg, v in pkgs.items()]
+        concurrent.futures.wait(futures, return_when=concurrent.futures.ALL_COMPLETED)

--- a/scale_build/packages/package.py
+++ b/scale_build/packages/package.py
@@ -57,10 +57,6 @@ class Package(BootstrapMixin, BuildPackageMixin, BuildCleanMixin, GitPackageMixi
         return other == self.name if isinstance(other, str) else self.name == other.name
 
     @property
-    def pkg_name(self):
-        return self.name
-
-    @property
     def log_file_path(self):
         return os.path.join(PKG_LOG_DIR, f'{self.name}.log')
 

--- a/scale_build/packages/package.py
+++ b/scale_build/packages/package.py
@@ -57,6 +57,10 @@ class Package(BootstrapMixin, BuildPackageMixin, BuildCleanMixin, GitPackageMixi
         return other == self.name if isinstance(other, str) else self.name == other.name
 
     @property
+    def pkg_name(self):
+        return self.name
+
+    @property
     def log_file_path(self):
         return os.path.join(PKG_LOG_DIR, f'{self.name}.log')
 


### PR DESCRIPTION
Parallelize the git checkout of repos. This greatly reduces the time needed to checkout the repos since it's currently being done synchronously. The major outlier is the `github.com/truenas/linux` repo for obvious reasons, but now all the other repos will be checked out without having to wait for that one to finish.

Original PR: https://github.com/truenas/scale-build/pull/262
Jira URL: https://jira.ixsystems.com/browse/NAS-115468