### PR TITLE
Improve logging when checking out

### DIFF
--- a/scale_build/packages/git.py
+++ b/scale_build/packages/git.py
@@ -55,6 +55,7 @@ class GitPackageMixin:
                 run(['git', '-C', self.source_path, 'checkout', branch])
 
         self.update_git_manifest()
+        logger.info('%r checkout complete', self.name)
 
     @property
     def existing_branch(self):


### PR DESCRIPTION
Once a package has completed checkout, we are not printing another statement showing that the package's checkout process is complete as otherwise with packages being checkout in parallel, it reduces visibility as to what is still active and what isn't.