### PR TITLE
NAS-115585 / 22.12 / Use golang 1.17 for building k3s

### DIFF
--- a/conf/build.manifest
+++ b/conf/build.manifest
@@ -171,6 +171,9 @@ apt_preferences:
 - Package: "*libnvcuvid*"
   Pin: "release n=bullseye-backports"
   Pin-Priority: 1000
+- Package: "*golang*"
+  Pin: "release n=bullseye-backports"
+  Pin-Priority: 1000
 #
 # List of additional packages installed into TrueNAS SCALE, along with link
 # to the ticket specifying the reason for requesting


### PR DESCRIPTION
K3s now wants to use at least golang 1.17 for building.