### PR TITLE
NAS-115605 / 22.12 / Fix ValueError crashes

### DIFF
--- a/scale_build/config.py
+++ b/scale_build/config.py
@@ -2,6 +2,8 @@ from os import environ, cpu_count
 from time import time
 from datetime import datetime
 
+_VERS = '22.12-MASTER'
+
 
 def get_env_variable(key, default_value, _type):
     value = environ.get(key)
@@ -38,4 +40,4 @@ SKIP_SOURCE_REPO_VALIDATION = get_env_variable('SKIP_SOURCE_REPO_VALIDATION', 0,
 TRAIN = get_env_variable('TRUENAS_TRAIN', '', str)
 TRUENAS_BRANCH_OVERRIDE = get_env_variable('TRUENAS_BRANCH_OVERRIDE', '', str)
 TRY_BRANCH_OVERRIDE = get_env_variable('TRY_BRANCH_OVERRIDE', '', str)
-VERSION = get_env_variable('TRUENAS_VERSION', f'22.12-MASTER-{BUILD_TIME_OBJ.strftime("%Y%m%d-%H%M%S")}', str)
+VERSION = get_env_variable('TRUENAS_VERSION', f'{_VERS}-{BUILD_TIME_OBJ.strftime("%Y%m%d-%H%M%S")}', str)

--- a/scale_build/config.py
+++ b/scale_build/config.py
@@ -1,25 +1,41 @@
-import os
-import time
-
+from os import environ, cpu_count
+from time import time
 from datetime import datetime
 
 
-BUILD_TIME = int(time.time())
+def get_env_variable(key, default_value, _type):
+    value = environ.get(key)
+    if value:
+        if _type == bool:
+            if value.isdigit():
+                return _type(value)
+            elif value.lower()[0] == 'y':
+                return True
+            elif value.lower()[0] == 'n':
+                return False
+            else:
+                # the variable is set but is something randon (i.e. VAR='please')
+                # so just assume it's set
+                return True
+        else:
+            return _type(value)
+    else:
+        return _type(default_value)
+
+
+BUILD_TIME = int(time())
 BUILD_TIME_OBJ = datetime.fromtimestamp(BUILD_TIME)
-BUILDER_DIR = os.getenv('BUILDER_DIR', './')
-BRANCH_OUT_NAME = os.getenv('NEW_BRANCH_NAME')
-BRANCH_OVERRIDES = {k[:-(len('_OVERRIDE'))]: v for k, v in os.environ.items() if k.endswith('_OVERRIDE')}
-FORCE_CLEANUP_WITH_EPOCH_CHANGE = bool(int(os.getenv('FORCE_CLEANUP_WITH_EPOCH_CHANGE') or '0'))
-GITHUB_TOKEN = os.getenv('GITHUB_TOKEN')
-PARALLEL_BUILD = int(os.getenv('PARALLEL_BUILDS', max(os.cpu_count(), 8) / 4))
-PKG_DEBUG = bool(int(os.getenv('PKG_DEBUG') or '0'))
-SIGNING_KEY = os.getenv('SIGNING_KEY')
-SIGNING_PASSWORD = os.getenv('SIGNING_PASSWORD')
-SKIP_SOURCE_REPO_VALIDATION = bool(int(os.getenv('SKIP_SOURCE_REPO_VALIDATION') or '0'))
-TRAIN = os.getenv('TRUENAS_TRAIN')
-TRUENAS_BRANCH_OVERRIDE = os.getenv('TRUENAS_BRANCH_OVERRIDE')
-TRY_BRANCH_OVERRIDE = os.getenv('TRY_BRANCH_OVERRIDE')
-if os.getenv('TRUENAS_VERSION'):
-    VERSION = os.getenv('TRUENAS_VERSION')
-else:
-    VERSION = f'22.12-MASTER-{BUILD_TIME_OBJ.strftime("%Y%m%d-%H%M%S")}'
+BUILDER_DIR = get_env_variable('BUILDER_DIR', './', str)
+BRANCH_OUT_NAME = get_env_variable('NEW_BRANCH_NAME', '', str)
+BRANCH_OVERRIDES = {k[:-(len('_OVERRIDE'))]: v for k, v in environ.items() if k.endswith('_OVERRIDE')}
+FORCE_CLEANUP_WITH_EPOCH_CHANGE = get_env_variable('FORCE_CLEANUP_WITH_EPOCH_CHANGE', 0, bool)
+GITHUB_TOKEN = get_env_variable('GITHUB_TOKEN', '', str)
+PARALLEL_BUILD = get_env_variable('PARALLEL_BUILDS', (max(cpu_count(), 8) / 4), int)
+PKG_DEBUG = get_env_variable('PKG_DEBUG', 0, bool)
+SIGNING_KEY = get_env_variable('SIGNING_KEY', '', str)
+SIGNING_PASSWORD = get_env_variable('SIGNING_PASSWORD', '', str)
+SKIP_SOURCE_REPO_VALIDATION = get_env_variable('SKIP_SOURCE_REPO_VALIDATION', 0, bool)
+TRAIN = get_env_variable('TRUENAS_TRAIN', '', str)
+TRUENAS_BRANCH_OVERRIDE = get_env_variable('TRUENAS_BRANCH_OVERRIDE', '', str)
+TRY_BRANCH_OVERRIDE = get_env_variable('TRY_BRANCH_OVERRIDE', '', str)
+VERSION = get_env_variable('TRUENAS_VERSION', f'22.12-MASTER-{BUILD_TIME_OBJ.strftime("%Y%m%d-%H%M%S")}', str)


### PR DESCRIPTION
I'm trying to work on some other tickets and I got a message to set `SKIP_SOURCE_REPO_VALIDATION` so I did `export SKIP_SOURCE_REPO_VALIDATION=y`

Tried to do `make packages` and it crashed with `ValueError` because we're trying to cast the result to `int`

With these changes, I've added a `get_env_variable` function that properly sets the environment variables in a programmatic way that should, hopefully, prevent these types of crashes in the future.