### PR TITLE
NAS-115606 / 22.02.1 / add rsync to depends in README.md (by yocalebo)

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ In addition to the host, you will want to pre-install the following packages:
 * squashfs-tools
 * unzip
 
-``` % sudo apt install build-essential debootstrap git python3-pip python3-venv squashfs-tools unzip libjson-perl```
+``` % sudo apt install build-essential debootstrap git python3-pip python3-venv squashfs-tools unzip libjson-perl rsync```
 
 ## Usage
 


### PR DESCRIPTION
I tried to do `make packages` and it crashed because `rsync` wasn't installed even though I simply copied and pasted the `apt install` command from the `README.md` 😄 

Add it to the `README.md` so lazy people like myself can copy and paste.

Original PR: https://github.com/truenas/scale-build/pull/267
Jira URL: https://jira.ixsystems.com/browse/NAS-115606