### PR TITLE
NAS-115250 / 22.02.1 / SCST changed upstream locations and fix build

### DIFF
--- a/conf/build.manifest
+++ b/conf/build.manifest
@@ -302,7 +302,11 @@ sources:
 - name: scst
   repo: https://github.com/truenas/scst
   generate_version: false
+  env:
+    KVER: "$(shell apt info linux-headers-truenas-amd64 | awk '/Source:/ { print $$2}' | sed 's/linux-//')"
+    KDIR: "/lib/modules/$(KVER)/build"
   prebuildcmd:
+    - "sed -i s/^DEBIAN_REVISION=.*/DEBIAN_REVISION=~truenas+1/g Makefile"
     - "make debian/changelog"
   buildcmd:
     - "make scst-dist-gzip"


### PR DESCRIPTION
SCST changed upstream locations and this repo has been changed to reflect that. This means our very minor patches to make this build were lost (as expected).

The good news is that we no longer to need to maintain a set of local patches, we can build directly from upstream using the patches in this PR.