### PR TITLE
NAS-115250 / 22.12 / SCST changed upstream locations and fix build (by yocalebo)

### DIFF
--- a/conf/build.manifest
+++ b/conf/build.manifest
@@ -335,7 +335,7 @@ sources:
     - "make scst-dist-gzip"
     - "make dpkg DEBEMAIL=no-reply@ixsystems.com DEBFULLNAME=TrueNAS"
   kernel_module: true
-  branch: truenas-svn-trunk
+  branch: master
   explicit_deps:
     - openzfs
 - name: truenas_binaries

--- a/conf/build.manifest
+++ b/conf/build.manifest
@@ -325,7 +325,11 @@ sources:
 - name: scst
   repo: https://github.com/truenas/scst
   generate_version: false
+  env:
+    KVER: "$(shell apt info linux-headers-truenas-amd64 | awk '/Source:/ { print $$2}' | sed 's/linux-//')"
+    KDIR: "/lib/modules/$(KVER)/build"
   prebuildcmd:
+    - "sed -i s/^DEBIAN_REVISION=.*/DEBIAN_REVISION=~truenas+1/g Makefile"
     - "make debian/changelog"
   buildcmd:
     - "make scst-dist-gzip"


### PR DESCRIPTION
SCST changed upstream locations and this repo has been changed to reflect that. This means our very minor patches to make this build were lost (as expected).

The good news is that we no longer to need to maintain a set of local patches, we can build directly from upstream using the patches in this PR.

Original PR: https://github.com/truenas/scale-build/pull/273
Jira URL: https://jira.ixsystems.com/browse/NAS-115250