### PR TITLE
NAS-115645 / 22.02.1 / Address CVE's in packages for angelfish

### DIFF
--- a/conf/build.manifest
+++ b/conf/build.manifest
@@ -181,7 +181,7 @@ apt_preferences:
 - Package: "*libexpat1*"
   Pin: "release n=bullseye-security"
   Pin-Priority: 1000
-- Package: "*openjdk-11-jre-headless*"
+- Package: "*openjdk-11*"
   Pin: "release n=bullseye-security"
   Pin-Priority: 1000
 #

--- a/conf/build.manifest
+++ b/conf/build.manifest
@@ -166,6 +166,24 @@ apt_preferences:
 - Package: "*docker*"
   Pin: "origin \"\""
   Pin-Priority: 950
+- Package: "*python3-lxml*"
+  Pin: "release n=bullseye-security"
+  Pin-Priority: 1000
+- Package: "*python3-pil*"
+  Pin: "release n=bullseye-security"
+  Pin-Priority: 1000
+- Package: "*apache2*"
+  Pin: "release n=bullseye-security"
+  Pin-Priority: 1000
+- Package: "*libnss3*"
+  Pin: "release n=bullseye-security"
+  Pin-Priority: 1000
+- Package: "*libexpat1*"
+  Pin: "release n=bullseye-security"
+  Pin-Priority: 1000
+- Package: "*openjdk-11-jre-headless*"
+  Pin: "release n=bullseye-security"
+  Pin-Priority: 1000
 #
 # List of additional packages installed into TrueNAS SCALE, along with link
 # to the ticket specifying the reason for requesting

--- a/conf/build.manifest
+++ b/conf/build.manifest
@@ -152,7 +152,7 @@ apt_preferences:
   Pin: "origin \"\""
   Pin-Priority: 1000
 - Package: "*ssl*"
-  Pin: "origin \"deb.debian.org\""
+  Pin: "release n=bullseye-security"
   Pin-Priority: 1000
 - Package: "*policykit*"
   Pin: "release n=bullseye-security"

--- a/scale_build/bootstrap/bootstrapdir.py
+++ b/scale_build/bootstrap/bootstrapdir.py
@@ -61,13 +61,8 @@ class BootstrapDir(CacheMixin, HashMixin):
             f.write(f'\n{deb_security}\n')
 
         run(['chroot', self.chroot_basedir, 'apt', 'update'])
-
-        if self.extra_packages_to_install:
-            run(['chroot', self.chroot_basedir, 'apt', 'install', '-y'] + self.extra_packages_to_install)
-
-        installed_packages = self.get_packages()
-
-        self.after_extra_packages_installation_steps()
+        # We need to have gnupg installed before adding apt mirrors because apt-key needs it
+        run(['chroot', self.chroot_basedir, 'apt', 'install', '-y', 'gnupg'])
 
         # Save the correct repo in sources.list
         apt_sources = [f'deb {apt_repos["url"]} {apt_repos["distribution"]} {apt_repos["components"]}']
@@ -87,6 +82,13 @@ class BootstrapDir(CacheMixin, HashMixin):
 
         # Update apt
         run(['chroot', self.chroot_basedir, 'apt', 'update'])
+
+        if self.extra_packages_to_install:
+            run(['chroot', self.chroot_basedir, 'apt', 'install', '-y'] + self.extra_packages_to_install)
+
+        installed_packages = self.get_packages()
+
+        self.after_extra_packages_installation_steps()
 
         # Put our local package up at the top of the food chain
         apt_sources.insert(0, 'deb [trusted=yes] file:/packages /')

--- a/scale_build/bootstrap/bootstrapdir.py
+++ b/scale_build/bootstrap/bootstrapdir.py
@@ -52,14 +52,6 @@ class BootstrapDir(CacheMixin, HashMixin):
         with open(os.path.join(apt_path, 'preferences'), 'w') as f:
             f.write(get_apt_preferences())
 
-        self.logger.debug('Adding debian-security to sources')
-        deb_security = '\n'.join([
-            'deb http://deb.debian.org/debian-security/ bullseye-security main',
-            'deb-src http://deb.debian.org/debian-security/ bullseye-security main',
-        ])
-        with open(apt_sources_path, 'a+') as f:
-            f.write(f'\n{deb_security}\n')
-
         run(['chroot', self.chroot_basedir, 'apt', 'update'])
         # We need to have gnupg installed before adding apt mirrors because apt-key needs it
         run(['chroot', self.chroot_basedir, 'apt', 'install', '-y', 'gnupg'])


### PR DESCRIPTION
This PR addresses following issues:

1. Backport bluefin fixes where we were not configuring mirrors before installing some base packages
2. Address CVE's in packages for angelfish
