### PR TITLE
NAS-115939 / 22.02.2 / Upgrade debian packages pulled in by debootstrap (by sonicaj)

### DIFF
--- a/conf/build.manifest
+++ b/conf/build.manifest
@@ -110,7 +110,7 @@ base-prune:
 # Update build-epoch when you want to force the next build to be
 # non-incremental
 ############################################################################
-build-epoch: 5
+build-epoch: 6
 
 # Apt Preferences
 ############################################################################

--- a/scale_build/bootstrap/bootstrapdir.py
+++ b/scale_build/bootstrap/bootstrapdir.py
@@ -74,6 +74,9 @@ class BootstrapDir(CacheMixin, HashMixin):
 
         # Update apt
         run(['chroot', self.chroot_basedir, 'apt', 'update'])
+        # Upgrade apt so that packages which were pulled in by debootstrap i.e libssl, they also
+        # respect the apt preferences we have specified
+        run(['chroot', self.chroot_basedir, 'apt', 'upgrade', '-y'])
 
         if self.extra_packages_to_install:
             run(['chroot', self.chroot_basedir, 'apt', 'install', '-y'] + self.extra_packages_to_install)


### PR DESCRIPTION
This PR fixes an issue where we ensure that the packages in the bootstrapped dir are actually what we want wrt apt preferences defined.

Original PR: https://github.com/truenas/scale-build/pull/292
Jira URL: https://jira.ixsystems.com/browse/NAS-115939