### PR TITLE
NAS-116170 / 22.02.2 / retry git commands on failure (by yocalebo)

### DIFF
--- a/scale_build/packages/git.py
+++ b/scale_build/packages/git.py
@@ -61,6 +61,12 @@ class GitPackageMixin:
                 ['git', '-C', self.source_path, 'checkout', branch],
             )
 
+        # We're doing retries here because at the time of writing this the iX network
+        # is having issues with an external hop through the routing of the interwebz
+        # getting to github.com. They've found a particular hop is dropping significant
+        # amounts of packets (~75%+). This is happening network wide so we've got the
+        # retries.
+        # NOTE: when the issue is fixed, we could remove this retry logic
         retries = 3 if retries <= 0 or retries > 10 else retries
         for i in range(1, retries + 1):
             if i == 1:

--- a/scale_build/packages/git.py
+++ b/scale_build/packages/git.py
@@ -84,7 +84,7 @@ class GitPackageMixin:
                 for cmd in cmds:
                     cp = run(cmd, check=False)
                     if cp.returncode:
-                        failed = (f'{" ".join(cmd)!r}', f'{cp.stderr!r}', f'{cp.returncode!r}')
+                        failed = (f'{" ".join(cmd)}', f'{cp.stderr}', f'{cp.returncode}')
                         break
 
             if failed:
@@ -99,7 +99,7 @@ class GitPackageMixin:
 
         self.update_git_manifest()
         log = 'Checkout ' if not update else 'Updating '
-        logger.info(log + 'of %r (using branch %r) complete', self.name, branch)
+        logger.info(log + 'of git repo %r (using branch %r) complete', self.name, branch)
 
     @property
     def existing_branch(self):

--- a/scale_build/packages/git.py
+++ b/scale_build/packages/git.py
@@ -88,7 +88,10 @@ class GitPackageMixin:
                         break
 
             if failed:
-                err = f'Failed cmd {failed[0]!r} with error {failed[1]!r} with returncode {failed[2]!r}'
+                failed_log_file = self.git_log_file + f'.failed.{i}'
+                err = f'Failed cmd {failed[0]!r} with error {failed[1]!r} with returncode {failed[2]!r}.'
+                err += f' Check {failed_log_file!r} for details.'
+                shutil.copyfile(self.git_log_file, failed_log_file)
                 if i == retries:
                     raise CallError(err)
                 else:


### PR DESCRIPTION
Our SCALE VM builders are failing to checkout git repos. The repo it fails on and when it fails are completely random. Until the root cause can be diagnosed and subsequently fixed, this will retry the update or checkout phase if a failure is encountered.

I've updated the logging verbiage so that we know when a retry is taking place.

Original PR: https://github.com/truenas/scale-build/pull/298
Jira URL: https://jira.ixsystems.com/browse/NAS-116170