### PR TITLE
NAS-116030 / 22.02.2 / Remove `truenas-devel` package (by themylogin)

### DIFF
--- a/conf/build.manifest
+++ b/conf/build.manifest
@@ -432,10 +432,6 @@ sources:
 - name: swagger
   repo: https://github.com/truenas/swagger
   branch: stable/angelfish
-- name: truenas_devel
-  repo: https://github.com/truenas/middleware
-  branch: master
-  subdir: src/truenas-devel
 - name: truenas_files
   repo: https://github.com/truenas/middleware
   branch: stable/angelfish


### PR DESCRIPTION
Automatic cherry-pick failed. Please resolve conflicts by running:

    git reset --hard HEAD~1
    git cherry-pick -x 4f6fbf159c3bb65b6d2c1c515b40a1effdd53665



Original PR: https://github.com/truenas/scale-build/pull/306
Jira URL: https://jira.ixsystems.com/browse/NAS-116030