### PR TITLE
NAS-116685 / 22.12 / Add update file size to manifest

### DIFF
--- a/scale_build/image/manifest.py
+++ b/scale_build/image/manifest.py
@@ -60,6 +60,7 @@ def build_release_manifest(update_file, update_file_checksum):
             'date': manifest['date'],
             'changelog': '',
             'checksum': update_file_checksum,
+            'filesize': os.path.getsize(update_file),
         }, f)
 
 


### PR DESCRIPTION
## Context

It was requested that we add size of the update file to the build manifest so that it can be used interactively by UI to determine if we have enough space to download the update file.