### PR TITLE
NAS-116844 / 22.12 / Update branch name for linux to truenas/linux-5.15

### DIFF
--- a/conf/build.manifest
+++ b/conf/build.manifest
@@ -266,7 +266,7 @@ sources:
   repo: https://github.com/truenas/inadyn.git
 - name: kernel
   repo: https://github.com/truenas/linux
-  branch: SCALE-v5.15-stable
+  branch: truenas/linux-5.15
   batch_priority: 0
   env:
     CONFIG_DEBUG_INFO: "Y"


### PR DESCRIPTION
The new branch name was chosen for consistency with other truenas repo
conventions.