### PR TITLE
NAS-117170 / 22.02.3 / bump version to 22.02.3

### DIFF
--- a/scale_build/config.py
+++ b/scale_build/config.py
@@ -2,7 +2,7 @@ from os import environ, cpu_count
 from time import time
 from datetime import datetime
 
-_VERS = '22.02.2-MASTER'
+_VERS = '22.02.3-MASTER'
 
 
 def get_env_variable(key, default_value, _type):


### PR DESCRIPTION
```
  File "/usr/lib/python3/dist-packages/middlewared/plugins/update_/install_linux.py", line 43, in _install
    raise CallError(f'Unable to downgrade from {old_version} to {new_version}')
middlewared.service_exception.CallError: [EFAULT] Unable to downgrade from 22.02.2.1 to 22.02.2-MASTER-20220713-041129
```