### PR TITLE
NAS-116521 / 22.12 / Add wheel group

### DIFF
--- a/conf/reference-files/etc/group
+++ b/conf/reference-files/etc/group
@@ -1,4 +1,5 @@
 root:x:0:
+wheel:x:0:
 daemon:x:1:
 bin:x:2:
 sys:x:3:


### PR DESCRIPTION
## Context

It was requested that we add a `wheel` group to help users migrating from CORE to SCALE making sure their workflow is not affected as in SCALE the group with same uid is known as `root` instead of `wheel`.