### PR TITLE
NAS-117519 / 22.12 / Various improvements to builder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@
 /tmp/
 /.buildEpoch
 build/
+identities/*
 dist/
 scale_build.egg-info/
 scale_build/__pycache__/

--- a/conf/build.manifest
+++ b/conf/build.manifest
@@ -1,6 +1,7 @@
 ---
 code_name: "Bluefin"
 debian_release: "bullseye"
+identity_file_path_default: "~/.ssh/id_rsa"
 #
 # List of apt repositories that are used and setup inside the build environment
 # for TrueNAS SCALE. These are used to pull additional packages or depend packages

--- a/conf/build.manifest
+++ b/conf/build.manifest
@@ -248,6 +248,10 @@ iso-packages:
 # to be built
 ############################################################################
 sources:
+- name: corssl
+  repo: git@github.com:iXsystems/corssl.git
+  branch: master
+  generate_version: false
 - name: docker
   repo: https://github.com/truenas/moby
   branch: truenas/20.10

--- a/conf/build.manifest
+++ b/conf/build.manifest
@@ -258,6 +258,10 @@ sources:
   repo: git@github.com:iXsystems/corssl.git
   branch: master
   generate_version: false
+  build_constraints:
+    - name: FIPS
+      value: true
+      type: boolean
 - name: docker
   repo: https://github.com/truenas/moby
   branch: truenas/20.10

--- a/conf/build.manifest
+++ b/conf/build.manifest
@@ -154,12 +154,18 @@ apt_preferences:
 - Package: "librrd*"
   Pin: "version 1.99*"
   Pin-Priority: 950
+- Package: "libssl1.1"
+  Pin:  "origin \"\""
+  Pin-Priority: 1100
 - Package: "*node*"
   Pin: "origin apt.tn.ixsystems.com/apt-direct/bluefin/nightlies/nodejs"
   Pin-Priority: 1000
 - Package: "*nvidia*"
   Pin: "release n=bullseye-backports"
   Pin-Priority: 1000
+- Package: "openssl"
+  Pin:  "origin \"\""
+  Pin-Priority: 1100
 - Package: "*policykit*"
   Pin: "release n=bullseye-security"
   Pin-Priority: 1000

--- a/conf/build.manifest
+++ b/conf/build.manifest
@@ -95,6 +95,8 @@ base-packages:
 - squashfs-tools
 - sysstat
 - truecommand-stats
+- libssl1.1
+- openssl
 - truenas
 - wireguard-dkms
 - wireguard-tools

--- a/scale_build/config.py
+++ b/scale_build/config.py
@@ -2,6 +2,7 @@ from os import environ, cpu_count
 from time import time
 from datetime import datetime
 
+IDENTITY_FILE_PATH_OVERRIDE_SUFFIX = '_OVERRIDE_IDENTITY_FILE_PATH'
 _VERS = '22.12-MASTER'
 
 
@@ -29,9 +30,10 @@ BUILD_TIME = int(time())
 BUILD_TIME_OBJ = datetime.fromtimestamp(BUILD_TIME)
 BUILDER_DIR = get_env_variable('BUILDER_DIR', './', str)
 BRANCH_OUT_NAME = get_env_variable('NEW_BRANCH_NAME', '', str)
-BRANCH_OVERRIDES = {k[:-(len('_OVERRIDE'))]: v for k, v in environ.items() if k.endswith('_OVERRIDE')}
+BRANCH_OVERRIDES = {}
 FORCE_CLEANUP_WITH_EPOCH_CHANGE = get_env_variable('FORCE_CLEANUP_WITH_EPOCH_CHANGE', 0, bool)
 GITHUB_TOKEN = get_env_variable('GITHUB_TOKEN', '', str)
+PACKAGE_IDENTITY_FILE_PATH_OVERRIDES = {}
 PARALLEL_BUILD = get_env_variable('PARALLEL_BUILDS', (max(cpu_count(), 8) / 4), int)
 PKG_DEBUG = get_env_variable('PKG_DEBUG', 0, bool)
 SIGNING_KEY = get_env_variable('SIGNING_KEY', '', str)
@@ -41,3 +43,11 @@ TRAIN = get_env_variable('TRUENAS_TRAIN', '', str)
 TRUENAS_BRANCH_OVERRIDE = get_env_variable('TRUENAS_BRANCH_OVERRIDE', '', str)
 TRY_BRANCH_OVERRIDE = get_env_variable('TRY_BRANCH_OVERRIDE', '', str)
 VERSION = get_env_variable('TRUENAS_VERSION', f'{_VERS}-{BUILD_TIME_OBJ.strftime("%Y%m%d-%H%M%S")}', str)
+
+
+# We will get branch overrides and identity file path overrides from here
+for k, v in environ.items():
+    if k.endswith('_OVERRIDE'):
+        BRANCH_OVERRIDES[k[:-(len('_OVERRIDE'))]] = v
+    elif k.endswith(IDENTITY_FILE_PATH_OVERRIDE_SUFFIX):
+        PACKAGE_IDENTITY_FILE_PATH_OVERRIDES[k[:-(len(IDENTITY_FILE_PATH_OVERRIDE_SUFFIX))]] = v

--- a/scale_build/config.py
+++ b/scale_build/config.py
@@ -14,7 +14,7 @@ def get_normalized_value(value, _type, default_value=None):
     if value:
         if _type == bool:
             if value.isdigit():
-                return _type(value)
+                return _type(int(value))
             elif value.lower()[0] == 'y':
                 return True
             elif value.lower()[0] == 'n':

--- a/scale_build/config.py
+++ b/scale_build/config.py
@@ -7,7 +7,10 @@ _VERS = '22.12-MASTER'
 
 
 def get_env_variable(key, _type, default_value=None):
-    value = environ.get(key)
+    return get_normalized_value(environ.get(key), _type, default_value)
+
+
+def get_normalized_value(value, _type, default_value=None):
     if value:
         if _type == bool:
             if value.isdigit():

--- a/scale_build/config.py
+++ b/scale_build/config.py
@@ -6,7 +6,7 @@ IDENTITY_FILE_PATH_OVERRIDE_SUFFIX = '_OVERRIDE_IDENTITY_FILE_PATH'
 _VERS = '22.12-MASTER'
 
 
-def get_env_variable(key, default_value, _type):
+def get_env_variable(key, _type, default_value=None):
     value = environ.get(key)
     if value:
         if _type == bool:
@@ -23,26 +23,26 @@ def get_env_variable(key, default_value, _type):
         else:
             return _type(value)
     else:
-        return _type(default_value)
+        return _type(default_value) if default_value else _type()
 
 
 BUILD_TIME = int(time())
 BUILD_TIME_OBJ = datetime.fromtimestamp(BUILD_TIME)
-BUILDER_DIR = get_env_variable('BUILDER_DIR', './', str)
-BRANCH_OUT_NAME = get_env_variable('NEW_BRANCH_NAME', '', str)
+BUILDER_DIR = get_env_variable('BUILDER_DIR', str, './')
+BRANCH_OUT_NAME = get_env_variable('NEW_BRANCH_NAME', str)
 BRANCH_OVERRIDES = {}
-FORCE_CLEANUP_WITH_EPOCH_CHANGE = get_env_variable('FORCE_CLEANUP_WITH_EPOCH_CHANGE', 0, bool)
-GITHUB_TOKEN = get_env_variable('GITHUB_TOKEN', '', str)
+FORCE_CLEANUP_WITH_EPOCH_CHANGE = get_env_variable('FORCE_CLEANUP_WITH_EPOCH_CHANGE', bool)
+GITHUB_TOKEN = get_env_variable('GITHUB_TOKEN', str)
 PACKAGE_IDENTITY_FILE_PATH_OVERRIDES = {}
-PARALLEL_BUILD = get_env_variable('PARALLEL_BUILDS', (max(cpu_count(), 8) / 4), int)
-PKG_DEBUG = get_env_variable('PKG_DEBUG', 0, bool)
-SIGNING_KEY = get_env_variable('SIGNING_KEY', '', str)
-SIGNING_PASSWORD = get_env_variable('SIGNING_PASSWORD', '', str)
-SKIP_SOURCE_REPO_VALIDATION = get_env_variable('SKIP_SOURCE_REPO_VALIDATION', 0, bool)
-TRAIN = get_env_variable('TRUENAS_TRAIN', '', str)
-TRUENAS_BRANCH_OVERRIDE = get_env_variable('TRUENAS_BRANCH_OVERRIDE', '', str)
-TRY_BRANCH_OVERRIDE = get_env_variable('TRY_BRANCH_OVERRIDE', '', str)
-VERSION = get_env_variable('TRUENAS_VERSION', f'{_VERS}-{BUILD_TIME_OBJ.strftime("%Y%m%d-%H%M%S")}', str)
+PARALLEL_BUILD = get_env_variable('PARALLEL_BUILDS', int, (max(cpu_count(), 8) / 4))
+PKG_DEBUG = get_env_variable('PKG_DEBUG', bool, 0)
+SIGNING_KEY = get_env_variable('SIGNING_KEY', str)
+SIGNING_PASSWORD = get_env_variable('SIGNING_PASSWORD', str)
+SKIP_SOURCE_REPO_VALIDATION = get_env_variable('SKIP_SOURCE_REPO_VALIDATION', bool)
+TRAIN = get_env_variable('TRUENAS_TRAIN', str)
+TRUENAS_BRANCH_OVERRIDE = get_env_variable('TRUENAS_BRANCH_OVERRIDE', str)
+TRY_BRANCH_OVERRIDE = get_env_variable('TRY_BRANCH_OVERRIDE', str)
+VERSION = get_env_variable('TRUENAS_VERSION', str, f'{_VERS}-{BUILD_TIME_OBJ.strftime("%Y%m%d-%H%M%S")}')
 
 
 # We will get branch overrides and identity file path overrides from here

--- a/scale_build/packages/git.py
+++ b/scale_build/packages/git.py
@@ -13,7 +13,7 @@ from scale_build.utils.git_utils import (
     retrieve_git_remote_and_sha, retrieve_git_branch, update_git_manifest
 )
 from scale_build.utils.logger import LoggingContext
-from scale_build.utils.manifest import SSH_SOURCE_REGEX
+from scale_build.utils.manifest import get_manifest, SSH_SOURCE_REGEX
 from scale_build.utils.paths import GIT_LOG_DIR_NAME, GIT_LOG_DIR
 from scale_build.utils.run import run
 
@@ -136,7 +136,9 @@ class GitPackageMixin:
     @property
     def get_identity_file_path(self):
         # We need to use absolute path as git changes it's working directory with -C
-        path = PACKAGE_IDENTITY_FILE_PATH_OVERRIDES.get(self.name) or self.identity_file_path
+        path = (PACKAGE_IDENTITY_FILE_PATH_OVERRIDES.get(self.name) or
+                self.identity_file_path or
+                get_manifest()['identity_file_path_default'])
         return os.path.abspath(path) if path else None
 
     @property

--- a/scale_build/packages/git.py
+++ b/scale_build/packages/git.py
@@ -123,9 +123,17 @@ class GitPackageMixin:
     @property
     def git_args(self):
         if self.ssh_based_source:
-            return ['git', '-c', 'core.sshCommand=ssh -i ./key -o StrictHostKeyChecking=\'accept-new\'']
+            return [
+                'git', '-c',
+                f'core.sshCommand=ssh -i {self.get_identity_file_path} -o StrictHostKeyChecking=\'accept-new\''
+            ]
         else:
             return ['git']
+
+    @property
+    def get_identity_file_path(self):
+        # We need to use absolute path as git changes it's working directory with -C
+        return os.path.abspath(self.identity_file_path)
 
     @property
     def ssh_based_source(self):
@@ -141,10 +149,10 @@ class GitPackageMixin:
                 f'in order to checkout {self.name!r}'
             )
 
-        if not os.path.exists(self.identity_file_path):
+        if not os.path.exists(self.get_identity_file_path):
             raise CallError(f'{self.identity_file_path!r} identity file path does not exist')
 
-        if oct(os.stat(self.identity_file_path).st_mode & 0o777) != '0o600':
+        if oct(os.stat(self.get_identity_file_path).st_mode & 0o777) != '0o600':
             raise CallError(f'{self.identity_file_path!r} identity file path should have 0o600 permissions')
 
     @property

--- a/scale_build/packages/git.py
+++ b/scale_build/packages/git.py
@@ -139,7 +139,7 @@ class GitPackageMixin:
         path = (PACKAGE_IDENTITY_FILE_PATH_OVERRIDES.get(self.name) or
                 self.identity_file_path or
                 get_manifest()['identity_file_path_default'])
-        return os.path.abspath(path) if path else None
+        return os.path.abspath(os.path.expanduser(path)) if path else None
 
     @property
     def ssh_based_source(self):

--- a/scale_build/packages/package.py
+++ b/scale_build/packages/package.py
@@ -13,7 +13,8 @@ from .clean import BuildCleanMixin
 from .git import GitPackageMixin
 from .overlay import OverlayMixin
 from .utils import (
-    DEPENDS_SCRIPT_PATH, gather_build_time_dependencies, normalize_build_depends, normalize_bin_packages_depends
+    DEPENDS_SCRIPT_PATH, gather_build_time_dependencies, get_normalized_build_constraint_value,
+    get_normalized_specified_build_constraint_value, normalize_build_depends, normalize_bin_packages_depends,
 )
 
 
@@ -25,12 +26,14 @@ class Package(BootstrapMixin, BuildPackageMixin, BuildCleanMixin, GitPackageMixi
         self, name, branch, repo, prebuildcmd=None, kernel_module=False, explicit_deps=None,
         generate_version=True, predepscmd=None, deps_path=None, subdir=None, deoptions=None, jobs=None,
         buildcmd=None, tmpfs=True, tmpfs_size=12, batch_priority=100, env=None, identity_file_path=None,
+        build_constraints=None,
     ):
         self.name = name
         self.branch = branch
         self.origin = repo
         self.prebuildcmd = prebuildcmd or []
         self.buildcmd = buildcmd or []
+        self.build_constraints = build_constraints or []
         self.kernel_module = kernel_module
         self.explicit_deps = set(explicit_deps or set())
         self.generate_version = generate_version
@@ -158,3 +161,11 @@ class Package(BootstrapMixin, BuildPackageMixin, BuildCleanMixin, GitPackageMixi
     @property
     def pkglist_hash_file_path(self):
         return os.path.join(HASH_DIR, f'{self.name}.pkglist')
+
+    @property
+    def to_build(self):
+        return all(
+            get_normalized_build_constraint_value(constraint) == get_normalized_specified_build_constraint_value(
+                constraint
+            ) for constraint in self.build_constraints
+        ) if self.build_constraints else True

--- a/scale_build/packages/package.py
+++ b/scale_build/packages/package.py
@@ -24,7 +24,7 @@ class Package(BootstrapMixin, BuildPackageMixin, BuildCleanMixin, GitPackageMixi
     def __init__(
         self, name, branch, repo, prebuildcmd=None, kernel_module=False, explicit_deps=None,
         generate_version=True, predepscmd=None, deps_path=None, subdir=None, deoptions=None, jobs=None,
-        buildcmd=None, tmpfs=True, tmpfs_size=12, batch_priority=100, env=None,
+        buildcmd=None, tmpfs=True, tmpfs_size=12, batch_priority=100, env=None, identity_file_path=None,
     ):
         self.name = name
         self.branch = branch
@@ -37,6 +37,7 @@ class Package(BootstrapMixin, BuildPackageMixin, BuildCleanMixin, GitPackageMixi
         self.predepscmd = predepscmd or []
         self.deps_path = deps_path
         self.subdir = subdir
+        self.identity_file_path = identity_file_path
         self.deoptions = deoptions
         self.jobs = jobs
         self.tmpfs = tmpfs

--- a/scale_build/packages/utils.py
+++ b/scale_build/packages/utils.py
@@ -38,4 +38,4 @@ def get_normalized_specified_build_constraint_value(value_schema):
 
 
 def get_normalized_build_constraint_value(value_schema):
-    return get_normalized_value(value_schema['value'], CONSTRAINT_MAPPING[value_schema['type']])
+    return get_normalized_value(str(value_schema['value']), CONSTRAINT_MAPPING[value_schema['type']])

--- a/scale_build/packages/utils.py
+++ b/scale_build/packages/utils.py
@@ -1,3 +1,11 @@
+from scale_build.config import get_env_variable, get_normalized_value
+
+
+CONSTRAINT_MAPPING = {
+    'boolean': bool,
+    'integer': int,
+    'string': str,
+}
 DEPENDS_SCRIPT_PATH = './scripts/parse_deps.pl'
 
 
@@ -23,3 +31,11 @@ def gather_build_time_dependencies(packages, deps, deps_list):
             packages, deps, packages[dep].install_dependencies | packages[dep].build_dependencies
         ))
     return deps
+
+
+def get_normalized_specified_build_constraint_value(value_schema):
+    return get_env_variable(value_schema['name'], CONSTRAINT_MAPPING[value_schema['type']])
+
+
+def get_normalized_build_constraint_value(value_schema):
+    return get_normalized_value(value_schema['value'], CONSTRAINT_MAPPING[value_schema['type']])

--- a/scale_build/utils/manifest.py
+++ b/scale_build/utils/manifest.py
@@ -179,7 +179,9 @@ def validate_manifest():
     invalid_packages = []
     for package in manifest['sources']:
         url = urlparse(package['repo'])
-        if url.hostname not in ['github.com', 'www.github.com'] or not url.path.startswith('/truenas/'):
+        if url.hostname not in ['github.com', 'www.github.com'] or not url.path.lower().startswith((
+            '/truenas/', '/ixsystems/'
+        )):
             invalid_packages.append(package['name'])
 
     if invalid_packages:

--- a/scale_build/utils/manifest.py
+++ b/scale_build/utils/manifest.py
@@ -18,6 +18,7 @@ MANIFEST_SCHEMA = {
     'properties': {
         'code_name': {'type': 'string'},
         'debian_release': {'type': 'string'},
+        'identity_file_path_default': {'type': 'string'},
         'apt-repos': {
             'type': 'object',
             'properties': {

--- a/scale_build/utils/manifest.py
+++ b/scale_build/utils/manifest.py
@@ -90,6 +90,27 @@ MANIFEST_SCHEMA = {
                         'type': 'array',
                         'items': [{'type': 'string'}],
                     },
+                    'build_constraints': {
+                        'type': 'array',
+                        'items': [{
+                            'type': 'object',
+                            'properties': {
+                                'name': {'type': 'string'},
+                                'value': {
+                                    'anyOf': [
+                                        {'type': 'string'},
+                                        {'type': 'integer'},
+                                        {'type': 'boolean'},
+                                    ],
+                                },
+                                'type': {
+                                    'type': 'string',
+                                    'enum': ['bool', 'string', 'integer'],
+                                },
+                                'required': ['name', 'value', 'type'],
+                            }
+                        }],
+                    },
                     'buildcmd': {
                         'type': 'array',
                         'items': [{'type': 'string'}],

--- a/scale_build/utils/manifest.py
+++ b/scale_build/utils/manifest.py
@@ -81,6 +81,7 @@ MANIFEST_SCHEMA = {
                 'properties': {
                     'name': {'type': 'string'},
                     'repo': {'type': 'string'},
+                    'identity_file_path': {'type': 'string'},
                     'branch': {'type': 'string'},
                     'batch_priority': {'type': 'integer'},
                     'predepscmd': {

--- a/scale_build/utils/manifest.py
+++ b/scale_build/utils/manifest.py
@@ -105,10 +105,10 @@ MANIFEST_SCHEMA = {
                                 },
                                 'type': {
                                     'type': 'string',
-                                    'enum': ['bool', 'string', 'integer'],
+                                    'enum': ['boolean', 'string', 'integer'],
                                 },
-                                'required': ['name', 'value', 'type'],
-                            }
+                            },
+                            'required': ['name', 'value', 'type'],
                         }],
                     },
                     'buildcmd': {
@@ -204,7 +204,7 @@ def validate_manifest():
     for package in manifest['sources']:
         repo_source = package['repo']
         if url := SSH_SOURCE_REGEX.findall(repo_source):
-            hostname, repo_path = url
+            hostname, repo_path = url[0]
         else:
             url = urlparse(repo_source)
             hostname = url.hostname

--- a/scale_build/utils/package.py
+++ b/scale_build/utils/package.py
@@ -4,4 +4,7 @@ from .manifest import get_manifest
 
 
 def get_packages():
-    return [Package(**pkg) for pkg in get_manifest()['sources']]
+    return [
+        pkg for pkg in map(lambda p: Package(**p), get_manifest()['sources'])
+        if pkg.to_build
+    ]


### PR DESCRIPTION
This PR introduces following changes:

1. Conditional builds of sources
2. Allowing ssh based origin of sources
3. Integrating corssl in TrueNAS for FIPS compliance
4. Various minor bug fixes and enhancements in the builder

Motivation behind the above changes is to basically allow building a separate version of TrueNAS SCALE which is FIPS compliant using CorSSL.

For consumers wishing to build FIPS compliant SCALE, they can set the env variable `FIPS=1` when checking out / building packages. Usage would look something like the following:

```
env corssl_OVERRIDE_IDENTITY_FILE_PATH=identities/key FIPS=1 sh -c "make checkout && make packages"
```

`corssl_OVERRIDE_IDENTITY_FILE_PATH` env variable is provided in order for `checkout` to succeed as `corssl` uses SSH based origin and an identity file must be provided either in the manifest or an environment variable so the build system can use that for checking out the repository in question.