### PR TITLE
NAS-108490 / 22.12 / Add ndctl and ipmctl packages to manage NVDIMMs.

### DIFF
--- a/conf/build.manifest
+++ b/conf/build.manifest
@@ -227,6 +227,10 @@ additional-packages:
   comment: requested by community (NAS-113898)
 - package: pv
   comment: requested by community (NAS-115638)
+- package: ndctl
+  comment: requested by community (NAS-108490)
+- package: ipmctl
+  comment: requested by community (NAS-108490)
 
 #
 # List of additional packages installed into TrueNAS SCALE ISO file


### PR DESCRIPTION
Those tools are mostly targeted to Intel Optane/DCPMM, especially the second, but some people may find them useful.