### PR TITLE
NAS-117776 / 22.12 / Clean chroot mounts when making update image

### DIFF
--- a/scale_build/update_image.py
+++ b/scale_build/update_image.py
@@ -4,7 +4,9 @@ import os
 
 from .bootstrap.bootstrapdir import PackageBootstrapDirectory
 from .exceptions import CallError
-from .image.bootstrap import clean_mounts, setup_chroot_basedir, umount_tmpfs_and_clean_chroot_dir
+from .image.bootstrap import (
+    clean_mounts, setup_chroot_basedir, umount_chroot_basedir, umount_tmpfs_and_clean_chroot_dir
+)
 from .image.manifest import update_file_path
 from .image.update import install_rootfs_packages, build_rootfs_image
 from .utils.logger import LoggingContext
@@ -99,6 +101,7 @@ def build_update_image_impl():
         with LoggingContext('rootfs-image', 'w'):
             build_rootfs_image()
     finally:
+        umount_chroot_basedir()
         umount_tmpfs_and_clean_chroot_dir()
 
     logger.info('Success! Update image created at: %s', update_file_path())


### PR DESCRIPTION
This commit fixes an issue where if we raise exception in reference files checks, chroot mounts are not properly cleaned up and we try to nuke the directory which results in builder removing already built packages.