### PR TITLE
NAS-118141 / 22.12 / allow easy checking of sha256 checksum

### DIFF
--- a/scale_build/image/iso.py
+++ b/scale_build/image/iso.py
@@ -164,8 +164,8 @@ def make_iso_file():
 
     with open(os.path.join(RELEASE_DIR, f'TrueNAS-SCALE-{get_image_version()}.iso.sha256'), 'w') as f:
         f.write(run(
-            ['sha256sum', os.path.join(RELEASE_DIR, f'TrueNAS-SCALE-{get_image_version()}.iso')], log=False).stdout.replace(f'{RELEASE_DIR}/', '').strip())
-
+            ['sha256sum', os.path.join(RELEASE_DIR, f'TrueNAS-SCALE-{get_image_version()}.iso')], log=False
+        ).stdout.replace(f'{RELEASE_DIR}/', '').strip())
 
 def prune_cd_basedir():
     for path in filter(os.path.exists, itertools.chain([

--- a/scale_build/image/iso.py
+++ b/scale_build/image/iso.py
@@ -167,6 +167,7 @@ def make_iso_file():
             ['sha256sum', os.path.join(RELEASE_DIR, f'TrueNAS-SCALE-{get_image_version()}.iso')], log=False
         ).stdout.replace(f'{RELEASE_DIR}/', '').strip())
 
+        
 def prune_cd_basedir():
     for path in filter(os.path.exists, itertools.chain([
         os.path.join(CHROOT_BASEDIR, 'var/cache/apt'),

--- a/scale_build/image/iso.py
+++ b/scale_build/image/iso.py
@@ -164,7 +164,7 @@ def make_iso_file():
 
     with open(os.path.join(RELEASE_DIR, f'TrueNAS-SCALE-{get_image_version()}.iso.sha256'), 'w') as f:
         f.write(run(
-            ['sha256sum', os.path.join(RELEASE_DIR, f'TrueNAS-SCALE-{get_image_version()}.iso')], log=False).stdout.replace(f'{RELEASE_DIR}/', '').strip()
+            ['sha256sum', os.path.join(RELEASE_DIR, f'TrueNAS-SCALE-{get_image_version()}.iso')], log=False).stdout.replace(f'{RELEASE_DIR}/', '').strip())
 
 
 def prune_cd_basedir():

--- a/scale_build/image/iso.py
+++ b/scale_build/image/iso.py
@@ -167,7 +167,7 @@ def make_iso_file():
             ['sha256sum', os.path.join(RELEASE_DIR, f'TrueNAS-SCALE-{get_image_version()}.iso')], log=False
         ).stdout.replace(f'{RELEASE_DIR}/', '').strip())
 
-        
+       
 def prune_cd_basedir():
     for path in filter(os.path.exists, itertools.chain([
         os.path.join(CHROOT_BASEDIR, 'var/cache/apt'),

--- a/scale_build/image/iso.py
+++ b/scale_build/image/iso.py
@@ -167,7 +167,7 @@ def make_iso_file():
             ['sha256sum', os.path.join(RELEASE_DIR, f'TrueNAS-SCALE-{get_image_version()}.iso')], log=False
         ).stdout.replace(f'{RELEASE_DIR}/', '').strip())
 
-        
+
 def prune_cd_basedir():
     for path in filter(os.path.exists, itertools.chain([
         os.path.join(CHROOT_BASEDIR, 'var/cache/apt'),

--- a/scale_build/image/iso.py
+++ b/scale_build/image/iso.py
@@ -164,8 +164,7 @@ def make_iso_file():
 
     with open(os.path.join(RELEASE_DIR, f'TrueNAS-SCALE-{get_image_version()}.iso.sha256'), 'w') as f:
         f.write(run(
-            ['sha256sum', os.path.join(RELEASE_DIR, f'TrueNAS-SCALE-{get_image_version()}.iso')], log=False
-        ).stdout.strip().split()[0])
+            ['sha256sum', os.path.join(RELEASE_DIR, f'TrueNAS-SCALE-{get_image_version()}.iso')], log=False).stdout.replace("./tmp/release/", ""))
 
 
 def prune_cd_basedir():

--- a/scale_build/image/iso.py
+++ b/scale_build/image/iso.py
@@ -167,7 +167,7 @@ def make_iso_file():
             ['sha256sum', os.path.join(RELEASE_DIR, f'TrueNAS-SCALE-{get_image_version()}.iso')], log=False
         ).stdout.replace(f'{RELEASE_DIR}/', '').strip())
 
-       
+        
 def prune_cd_basedir():
     for path in filter(os.path.exists, itertools.chain([
         os.path.join(CHROOT_BASEDIR, 'var/cache/apt'),

--- a/scale_build/image/iso.py
+++ b/scale_build/image/iso.py
@@ -164,7 +164,7 @@ def make_iso_file():
 
     with open(os.path.join(RELEASE_DIR, f'TrueNAS-SCALE-{get_image_version()}.iso.sha256'), 'w') as f:
         f.write(run(
-            ['sha256sum', os.path.join(RELEASE_DIR, f'TrueNAS-SCALE-{get_image_version()}.iso')], log=False).stdout.replace("./tmp/release/", ""))
+            ['sha256sum', os.path.join(RELEASE_DIR, f'TrueNAS-SCALE-{get_image_version()}.iso')], log=False).stdout.replace(f'{RELEASE_DIR}/', '').strip()
 
 
 def prune_cd_basedir():


### PR DESCRIPTION
Joe should be discussing this PR with Waqar.

This will allow us to automate the shasum checking in our jenkins pipline since the shasum file will now be made so that we can use `shasum -c ` to verify its correct once the push has happened.
![image](https://user-images.githubusercontent.com/4654247/188697143-afc530ce-64b0-42bd-8861-d4711de76ca9.png)
