### PR TITLE
NAS-118239 / 22.02.4 / Remove redundant debian-security mirror

### DIFF
--- a/conf/build.manifest
+++ b/conf/build.manifest
@@ -38,9 +38,6 @@ apt-repos:
   - url: http://apt.tn.ixsystems.com/apt-direct/angelfish/nightlies/debian-security/
     distribution: bullseye-security
     component: main
-  - url: http://apt.tn.ixsystems.com/apt-direct/angelfish/22.02.3/debian-security-22.02.3/
-    distribution: bullseye-security
-    component: main
   - url: http://apt.tn.ixsystems.com/apt-direct/angelfish/nightlies/debian-backports/
     distribution: bullseye-backports
     component: "main contrib non-free"

--- a/conf/build.manifest
+++ b/conf/build.manifest
@@ -202,6 +202,9 @@ apt_preferences:
 - Package: "*librte*"
   Pin: "release n=bullseye-security"
   Pin-Priority: 1000
+- Package: "*tls*"
+  Pin: "release n=bullseye-security"
+  Pin-Priority: 1000
 - Package: "*nvidia*"
   Pin: "release n=bullseye-backports"
   Pin-Priority: 1000

--- a/conf/sources.list
+++ b/conf/sources.list
@@ -7,6 +7,5 @@ deb http://apt.tn.ixsystems.com/apt-direct/angelfish/nightlies/nvidia-docker/ bu
 deb http://apt.tn.ixsystems.com/apt-direct/angelfish/nightlies/debian/ bullseye main
 deb http://apt.tn.ixsystems.com/apt-direct/angelfish/nightlies/debian-debug/ bullseye-debug main
 deb http://apt.tn.ixsystems.com/apt-direct/angelfish/nightlies/debian-security/ bullseye-security main
-deb http://apt.tn.ixsystems.com/apt-direct/angelfish/22.02.3/debian-security-22.02.3/ bullseye-security main
 deb http://apt.tn.ixsystems.com/apt-direct/angelfish/nightlies/debian-backports/ bullseye-backports main contrib non-free
 deb http://apt.tn.ixsystems.com/apt-direct/angelfish/nightlies/helm/ all main


### PR DESCRIPTION
This commit removes redundant security mirror we added for 22.02.3 as this time we have updated the security mirror we have for angelfish.