### PR TITLE
NAS-111127 / 22.12 / Load drivetemp module

### DIFF
--- a/conf/cd-files/etc/modules-load.d/drivetemp.conf
+++ b/conf/cd-files/etc/modules-load.d/drivetemp.conf
@@ -1,0 +1,3 @@
+# TrueNAS managed
+# Load drivetemp to allow monitoring via hwmon.
+drivetemp


### PR DESCRIPTION
Load the `drivetemp` module[0] in order to allow monitoring of disk temps via hwmon/lm-sensors.

[0]: https://www.kernel.org/doc/html/latest/hwmon/drivetemp.html

Signed-off-by: SuperQ <superq@gmail.com>