### PR TITLE
[NAS-118248] Add sysfsutils package

### DIFF
--- a/conf/build.manifest
+++ b/conf/build.manifest
@@ -237,6 +237,8 @@ additional-packages:
   comment: requested by community (NAS-108490)
 - package: ipmctl
   comment: requested by community (NAS-108490)
+- package: sysfsutils
+  comment: requested by community (NAS-118248)
 
 #
 # List of additional packages installed into TrueNAS SCALE ISO file


### PR DESCRIPTION
Add the `sysfsutils` package to the build manifest. This allows simple tweaks of file attributes in the `/sys` filesystem.

Signed-off-by: SuperQ <superq@gmail.com>