### PR TITLE
NAS-118500 / 22.12 / Include avahi-utils in the build

### DIFF
--- a/conf/build.manifest
+++ b/conf/build.manifest
@@ -67,6 +67,7 @@ base-packages:
 - linux-image-truenas-amd64
 - linux-perf
 - avahi-daemon
+- avahi-utils
 - nfs-kernel-server
 - bpftrace
 - bpfcc-tools


### PR DESCRIPTION
These tools may be useful for diagnosing mDNS issues in field as well as doing CI.