### PR TITLE
NAS-118134 / 22.12 / Add libgfapi python bindings for build

### DIFF
--- a/conf/build.manifest
+++ b/conf/build.manifest
@@ -261,6 +261,9 @@ sources:
 - name: inadyn
   branch: master
   repo: https://github.com/truenas/inadyn.git
+- name: pyglfs
+  branch: master
+  repo: https://github.com/truenas/pyglfs.git
 - name: kernel
   repo: https://github.com/truenas/linux
   branch: truenas/linux-5.15


### PR DESCRIPTION
These are used by CTDB mutex helper script to maintain cluster recovery lock.