### PR TITLE
NAS-118856 / 22.12 / remove incorrect headers package

### DIFF
--- a/conf/build.manifest
+++ b/conf/build.manifest
@@ -62,7 +62,6 @@ apt-repos:
 base-packages:
 - dosfstools
 - linux-truenas-libc-dev
-- linux-headers-amd64
 - linux-headers-truenas-amd64
 - linux-image-truenas-amd64
 - linux-perf


### PR DESCRIPTION
This causes us to ship kernel objects (specifically the nvidia dkms related packages) that have been built against an incorrect kernel version that SCALE does not run.