### PR TITLE
NAS-113872 / 22.12 / Patch ndctl to improve NVDIMM health monitoring.

### DIFF
--- a/conf/build.manifest
+++ b/conf/build.manifest
@@ -485,3 +485,11 @@ sources:
     - "./pull.sh"
   deoptions: nocheck
   generate_version: false
+- name: ndctl
+  repo: https://github.com/truenas/ndctl
+  branch: main
+  predepscmd:
+    - "apt install -y wget xz-utils"
+    - "./pull.sh"
+  deoptions: nocheck
+  generate_version: false


### PR DESCRIPTION
Upstream version is too naive in reporting "health_state".  This should be more consistent with specs within limitations of ndctl internal APIs, based on Intel DCPMM/Optane.