### PR TITLE
NAS-119312 / 23.10 / fix exclusive action condition

### DIFF
--- a/scale_build/main.py
+++ b/scale_build/main.py
@@ -78,7 +78,7 @@ def main():
     if args.action == 'checkout':
         check_epoch()
         checkout_sources()
-    if args.action == 'check_upstream_package_updates':
+    elif args.action == 'check_upstream_package_updates':
         check_upstream_package_updates()
     elif args.action == 'packages':
         validate()


### PR DESCRIPTION
Fix exclusive action, the related commit is https://github.com/truenas/scale-build/commit/f1b38c78bb01cf3e065327ed9b81e3782701486e.

Before the fix:

ArgParser print help messages between commands `scale_build checkout` and `scale_build packages`

After the fix:

No help messages anymore.
