### PR TITLE
NAS-119315 / 23.10 / Add convmv package to base install

### DIFF
--- a/conf/build.manifest
+++ b/conf/build.manifest
@@ -106,6 +106,7 @@ base-packages:
 - zfs-test
 - zfs-initramfs
 - nvme-cli
+- convmv
 
 #
 # Packages which are removed from the base TrueNAS SCALE System by default


### PR DESCRIPTION
This gives administrator ability to convert character encoding types for file names. This can be a  matter of last resort for normalizing file names in ways that are compatible across all clients.