### PR TITLE
NAS-119315 / 22.12.1 / Add convmv package to base install (by anodos325)

### DIFF
--- a/conf/build.manifest
+++ b/conf/build.manifest
@@ -106,6 +106,7 @@ base-packages:
 - zfs-test
 - zfs-initramfs
 - nvme-cli
+- convmv
 
 #
 # Packages which are removed from the base TrueNAS SCALE System by default


### PR DESCRIPTION
This gives administrator ability to convert character encoding types for file names. This can be a  matter of last resort for normalizing file names in ways that are compatible across all clients.

Original PR: https://github.com/truenas/scale-build/pull/368
Jira URL: https://ixsystems.atlassian.net/browse/NAS-119315