### PR TITLE
NAS-119820 / 23.10 / build SCST off upstream stable 3.7.x branch

### DIFF
--- a/conf/build.manifest
+++ b/conf/build.manifest
@@ -348,7 +348,7 @@ sources:
     - "make scst-dist-gzip"
     - "make dpkg DEBEMAIL=no-reply@ixsystems.com DEBFULLNAME=TrueNAS"
   kernel_module: true
-  branch: master
+  branch: truenas-3.7.x
   explicit_deps:
     - openzfs
 - name: truenas_binaries


### PR DESCRIPTION
Upstream SCST has finally branched for their 3.7 branch which means it's become "stable".

I've created a `truenas-3.7.x` branch that is based off upstream `3.7.x` branch.

