### PR TITLE
NAS-120670 / 22.12.2 / Add ftp group to build (by anodos325)

### DIFF
--- a/conf/reference-files/etc/group
+++ b/conf/reference-files/etc/group
@@ -12,6 +12,7 @@ news:x:9:
 uucp:x:10:
 man:x:12:
 proxy:x:13:
+ftp:x:14:
 kmem:x:15:
 dialout:x:20:nut
 fax:x:21:


### PR DESCRIPTION
gid 14 is FTP group in FreeBSD. We need this in SCALE to ensure that permissions work correctly on migrations from Core->SCALE where FTP configuration may rely on this group / gid.

Original PR: https://github.com/truenas/scale-build/pull/379
Jira URL: https://ixsystems.atlassian.net/browse/NAS-120670