### PR TITLE
NAS-120648 / 23.10 / Add bison package to iso

### DIFF
--- a/conf/build.manifest
+++ b/conf/build.manifest
@@ -80,6 +80,7 @@ base-packages:
 - grub-efi-amd64-bin
 - htop
 - ifstat
+- bison
 - nvidia-kernel-dkms
 - nslcd
 - nvidia-container-toolkit


### PR DESCRIPTION
bison is a rutime dependency for samba with
elasticsearch spotlight backend.