### PR TITLE
NAS-121239 / 22.12.3 / fix build (by yocalebo)

### DIFF
--- a/conf/reference-files/etc/group
+++ b/conf/reference-files/etc/group
@@ -78,3 +78,4 @@ docker:x:999:
 libvirt-qemu:x:64055:libvirt-qemu
 haproxy:x:130:
 uuidd:x:131:
+i2c:x:132:


### PR DESCRIPTION
i2c-tools creates a new local user `i2c`.

Original PR: https://github.com/truenas/scale-build/pull/391
Jira URL: https://ixsystems.atlassian.net/browse/NAS-121239