### PR TITLE
NAS-121450 / 23.10 / add ndctl proper package

### DIFF
--- a/conf/build.manifest
+++ b/conf/build.manifest
@@ -200,6 +200,8 @@ additional-packages:
   comment: requested by community (NAS-113898)
 - package: pv
   comment: requested by community (NAS-115638)
+- package: ndctl
+  comment: requested by community (NAS-108490)
 - package: ipmctl
   comment: requested by community (NAS-108490)
 - package: acpica-tools


### PR DESCRIPTION
This adds the ndctl proper package. Since Cobia is based off bookworm, this pulls in a new upstream version which includes Mav's many fixes.