### PR TITLE
NAS-121477 / 23.10 / remove unused repo

### DIFF
--- a/conf/build.manifest
+++ b/conf/build.manifest
@@ -428,9 +428,6 @@ sources:
 - name: sedutil
   repo: https://github.com/truenas/sedutil
   branch: master
-- name: pydevd
-  repo: https://github.com/truenas/pydevd.git
-  branch: master
 - name: python_netsnmpagent
   repo: https://github.com/truenas/python-netsnmpagent
   branch: master


### PR DESCRIPTION
This is being removed in Cobia since our fork hasn't been updated in 3 years but even more so, we are no longer using it in middleware repo. See https://github.com/truenas/middleware/pull/11109 for details.