### PR TITLE
NAS-121556 / 23.10 / Add ixdiagnose to build

### DIFF
--- a/conf/build.manifest
+++ b/conf/build.manifest
@@ -463,6 +463,9 @@ sources:
   deps_path: packaging/debian
   explicit_deps:
     - openzfs
+- name: ixdiagnose
+  repo: https://github.com/truenas/ixdiagnose
+  branch: master
 - name: catalog_validation
   repo: https://github.com/truenas/catalog_validation
   branch: master


### PR DESCRIPTION
## Context

In order to integrate ixdiagnose to middleware we need to add it to scale build so it's debian package (PR up for ixdiagnose debian package https://github.com/truenas/ixdiagnose/pull/15) can then be consumed by middlewared debian package build.