### PR TITLE
NAS-121733 / 22.12.3 / remove opensc from base image (by yocalebo)

### DIFF
--- a/conf/build.manifest
+++ b/conf/build.manifest
@@ -120,6 +120,10 @@ base-prune:
 - libgdk-pixbuf2.0-0
 - x11-common
 - python-is-python2
+# dependency tree openvpn->easy-rsa->opensc
+# we don't need this package since it's for dealing with smart cards
+# but more importantly, removes a category of potentical CVE exposure
+- opensc
 
 #
 # Update build-epoch when you want to force the next build to be


### PR DESCRIPTION
This package is for dealing with smart cards. More importantly, however, is that it has active CVE vulnerabilities that need to be patched. This is brought in via the `easy-rsa` package which is brought in via the `openvpn` service. We, obviously, can't remove openvpn but we can safely remove opensc.

Original PR: https://github.com/truenas/scale-build/pull/404
Jira URL: https://ixsystems.atlassian.net/browse/NAS-121733