### PR TITLE
NAS-121888 / 23.10 / Remove kernel module flag from builder

### DIFF
--- a/conf/build.manifest
+++ b/conf/build.manifest
@@ -363,7 +363,9 @@ sources:
     - "make 2perf"
     - "make scst-dist-gzip"
     - "make dpkg DEBEMAIL=no-reply@ixsystems.com DEBFULLNAME=TrueNAS"
-  kernel_module: true
+  explicit_deps:
+    - kernel
+    - kernel-dbg
   branch: truenas-3.7.x
   subpackages:
     - name: scst-dbg
@@ -381,7 +383,9 @@ sources:
         - "make 2debug"
         - "make scst-dist-gzip"
         - "make dpkg DEBEMAIL=no-reply@ixsystems.com DEBFULLNAME=TrueNAS"
-      kernel_module: true
+      explicit_deps:
+        - kernel
+        - kernel-dbg
 - name: truenas_binaries
   repo: https://github.com/truenas/binaries
   branch: master

--- a/conf/build.manifest
+++ b/conf/build.manifest
@@ -296,7 +296,9 @@ sources:
     - "dpkg-buildpackage -us -uc -b"
     - "rm ../openzfs-zfs-dkms*.deb ../openzfs-zfs-dracut*.deb"
     - "debian/rules override_dh_binary-modules"
-  kernel_module: true
+  explicit_deps:
+    - kernel
+    - kernel-dbg
   generate_version: false
   subpackages:
     - name: openzfs-dbg
@@ -321,8 +323,8 @@ sources:
         - "sh autogen.sh"
         - "./scripts/make_gitrev.sh"
         - "debian/rules override_dh_binary-modules"
-      kernel_module: true
       explicit_deps:
+        - kernel
         - kernel-dbg
       generate_version: false
 - name: truenas_samba

--- a/scale_build/packages/build.py
+++ b/scale_build/packages/build.py
@@ -64,13 +64,6 @@ class BuildPackageMixin:
         if os.path.exists(os.path.join(self.dpkg_overlay_packages_path, 'Packages.gz')):
             self.run_in_chroot('apt update')
 
-        if self.kernel_module:
-            self.logger.debug('Installing truenas linux headers')
-            self.run_in_chroot('apt install -y /packages/linux-headers-truenas-production-amd64_*.deb')
-            self.run_in_chroot('apt install -y /packages/linux-headers-truenas-debug-amd64_*.deb')
-            self.run_in_chroot('apt install -y /packages/linux-image-truenas-production-amd64_*.deb')
-            self.run_in_chroot('apt install -y /packages/linux-image-truenas-debug-amd64_*.deb')
-
         self.execute_pre_depends_commands()
 
         self.run_in_chroot(f'cd {self.package_source} && mk-build-deps --build-dep', 'Failed mk-build-deps')

--- a/scale_build/packages/package.py
+++ b/scale_build/packages/package.py
@@ -24,7 +24,7 @@ logger = logging.getLogger(__name__)
 
 class Package(BootstrapMixin, BuildPackageMixin, BuildCleanMixin, GitPackageMixin, OverlayMixin):
     def __init__(
-        self, name, branch, repo, prebuildcmd=None, kernel_module=False, explicit_deps=None,
+        self, name, branch, repo, prebuildcmd=None, explicit_deps=None,
         generate_version=True, predepscmd=None, deps_path=None, subdir=None, deoptions=None, jobs=None,
         buildcmd=None, tmpfs=True, tmpfs_size=12, batch_priority=100, env=None, identity_file_path=None,
         build_constraints=None, debian_fork=False, source_name=None, depscmd=None,
@@ -37,7 +37,6 @@ class Package(BootstrapMixin, BuildPackageMixin, BuildCleanMixin, GitPackageMixi
         self.buildcmd = buildcmd or []
         self.build_constraints = build_constraints or []
         self.depscmd = depscmd or []
-        self.kernel_module = kernel_module
         self.explicit_deps = set(explicit_deps or set())
         self.generate_version = generate_version
         self.predepscmd = predepscmd or []

--- a/scale_build/packages/package.py
+++ b/scale_build/packages/package.py
@@ -108,10 +108,9 @@ class Package(BootstrapMixin, BuildPackageMixin, BuildCleanMixin, GitPackageMixi
 
             cp = run([DEPENDS_SCRIPT_PATH, control_file_path], log=False)
             info = json.loads(cp.stdout)
-            default_dependencies = {'kernel', 'kernel-dbg'} if self.kernel_module else set()
             self.build_depends = set(
                 normalize_build_depends(info['source_package']['build_depends'])
-            ) | default_dependencies
+            ) | self.explicit_deps
             self.source_package = info['source_package']['name']
             for bin_package in info['binary_packages']:
                 self._binary_packages.append(BinaryPackage(

--- a/scale_build/tests/unit/test_package_rebuild_logic.py
+++ b/scale_build/tests/unit/test_package_rebuild_logic.py
@@ -18,10 +18,10 @@ BUILD_MANIFEST = {
                 {
                     'name': 'openzfs-dbg',
                     'deps_path': 'contrib/debian',
-                    'kernel_module': True,
+                    'explicit_deps': ['kernel', 'kernel-dbg'],
                 }
             ],
-            'kernel_module': True,
+            'explicit_deps': ['kernel', 'kernel-dbg'],
         },
         {
             'name': 'kernel',
@@ -38,12 +38,12 @@ BUILD_MANIFEST = {
             'name': 'scst',
             'repo': 'https://github.com/truenas/scst',
             'branch': 'truenas-3.7.x',
-            'kernel_module': True,
+            'explicit_deps': ['kernel', 'kernel-dbg'],
             'subpackages': [
                 {
                     'name': 'scst-dbg',
                     'branch': 'truenas-3.7.x',
-                    'kernel_module': True,
+                    'explicit_deps': ['kernel', 'kernel-dbg'],
                 }
             ]
         },

--- a/scale_build/utils/manifest.py
+++ b/scale_build/utils/manifest.py
@@ -57,7 +57,6 @@ INDIVIDUAL_REPO_SCHEMA = {
             'items': [{'type': 'string'}],
         },
         'deps_path': {'type': 'string'},
-        'kernel_module': {'type': 'boolean'},
         'generate_version': {'type': 'boolean'},
         'explicit_deps': {
             'type': 'array',


### PR DESCRIPTION
This PR adds changes to remove kernel module flag as it was introduced to handle the cases where linux kernel headers debian package's name changed each time there were changes in kernel headers which meant that relevant repositories needed to be updated to reflect that change.

However with recent truenas kernel changes, those names are now static and we can properly specify build/install time dependencies instead of injecting these dependencies in the build/install environment which means that the whole process now goes throught apt and is handled like any other package.