### PR TITLE
NAS-122119 / 22.12.3 / use LD_LIBRARY_PATH when installing / upgrading

### DIFF
--- a/truenas_install/__main__.py
+++ b/truenas_install/__main__.py
@@ -426,7 +426,9 @@ def main():
                             if old_bootfs_prop != "-":
                                 run_command(["zfs", "set", "truenas:12=1", old_bootfs_prop])
 
+                        os.environ['LD_LIBRARY_PATH'] = f'{root}/usr/lib'
                         cp = run_command([f"{root}/usr/local/bin/truenas-initrd.py", root], check=False)
+                        os.environ.pop('LD_LIBRARY_PATH', None)
                         if cp.returncode > 1:
                             raise subprocess.CalledProcessError(
                                 cp.returncode, f'Failed to execute truenas-initrd: {cp.stderr}'

--- a/truenas_install/__main__.py
+++ b/truenas_install/__main__.py
@@ -27,6 +27,9 @@ RE_UNSQUASHFS_PROGRESS = re.compile(r"\[.+\]\s+(?P<extracted>[0-9]+)/(?P<total>[
 run_kw = dict(check=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE, encoding="utf-8", errors="ignore")
 
 IS_FREEBSD = platform.system().upper() == "FREEBSD"
+LD_LOAD_PATHS = [
+    '/usr/lib/x86_64-linux-gnu'
+]
 is_json_output = False
 
 
@@ -426,7 +429,11 @@ def main():
                             if old_bootfs_prop != "-":
                                 run_command(["zfs", "set", "truenas:12=1", old_bootfs_prop])
 
-                        os.environ['LD_LIBRARY_PATH'] = f'{root}/usr/lib'
+                        for p in LD_LOAD_PATHS:
+                            if not os.path.exists(f'{root}/{p}'):
+                                write_error(f"{root}/{p}: library path does not exist.", raise_=True)
+
+                        os.environ['LD_LIBRARY_PATH'] = ':'.join([f'{root}/{p}' for p in LD_LOAD_PATHS])
                         cp = run_command([f"{root}/usr/local/bin/truenas-initrd.py", root], check=False)
                         os.environ.pop('LD_LIBRARY_PATH', None)
                         if cp.returncode > 1:


### PR DESCRIPTION
Python modules imported within the truenas-initrd.py script may link against libs that are only present in the squashfs dir and so we should make ld aware of the usr/lib dir within it since we're not chrooted.