### PR TITLE
Add parted tool in installer image to set PMBR boot flag

### DIFF
--- a/conf/build.manifest
+++ b/conf/build.manifest
@@ -239,6 +239,7 @@ iso-packages:
 - jq
 - live-boot
 - truenas-installer
+- parted
 - pciutils
 - python3-libzfs
 - python3-pyudev


### PR DESCRIPTION
sgdisk does not allow to set pmbr_boot flag.

For context: https://github.com/truenas/truenas-installer/pull/62 