### PR TITLE
NAS-121623 / 23.10 / Allow not installing recommended packages of a package

### DIFF
--- a/conf/build.manifest
+++ b/conf/build.manifest
@@ -205,42 +205,61 @@ apt_preferences:
 additional-packages:
 - package: xtail
   comment: used by support (NAS-108788)
+  install_recommends: true
 - package: iperf3
   comment: requested by sales (NAS-108787)
+  install_recommends: true
 - package: fio
   comment: requested by sales (NAS-108787)
+  install_recommends: true
 - package: dnsutils
   comment: requested by community (NAS-109391)
+  install_recommends: true
 - package: traceroute
   comment: requested by platform and perf (NAS-110493)
+  install_recommends: true
 - package: openseachest
   comment: requested by performance team (NAS-106154)
+  install_recommends: true
 - package: cxgbtool
   comment: requested by OS team (NAS-111041)
+  install_recommends: true
 - package: python-is-python3
   comment: NAS-111358 (symlinks /usr/bin/python to python3)
+  install_recommends: true
 - package: sdparm
   comment: NAS-114723
+  install_recommends: true
 - package: powertop
   comment: requested by community (NAS-113898)
+  install_recommends: true
 - package: pv
   comment: requested by community (NAS-115638)
+  install_recommends: true
 - package: ndctl
   comment: requested by community (NAS-108490)
+  install_recommends: true
 - package: ipmctl
   comment: requested by community (NAS-108490)
+  install_recommends: true
 - package: acpica-tools
   comment: requested by platform team (NAS-118432)
+  install_recommends: true
 - package: freeipmi
   comment: requested by engineering (NAS-121050)
+  install_recommends: true
 - package: cu
   comment: requested by platform team (NAS-120155)
+  install_recommends: true
 - package: lrzsz
   comment: requested by platform team (NAS-120155)
+  install_recommends: true
 - package: minicom
   comment: requested by platform team (NAS-120155)
+  install_recommends: true
 - package: i2c-tools
   comment: requested by platform team (NAS-120155)
+  install_recommends: true
 
 #
 # List of additional packages installed into TrueNAS SCALE ISO file

--- a/conf/build.manifest
+++ b/conf/build.manifest
@@ -44,55 +44,102 @@ apt-repos:
 # NOTE: Installed in the order listed
 ############################################################################
 base-packages:
-- dosfstools
-- linux-truenas-production-libc-dev
-- linux-headers-truenas-production-amd64
-- linux-headers-truenas-debug-amd64
-- linux-image-truenas-production-amd64
-- linux-image-truenas-debug-amd64
-- linux-perf-truenas
-- avahi-daemon
-- avahi-utils
-- nfs-kernel-server
-- bpftrace
-- bpfcc-tools 
-- firmware-bnx2
-- firmware-bnx2x
-- firmware-cavium
-- firmware-linux
-- firmware-myricom
-- firmware-netronome
-- firmware-netxen
-- firmware-qlogic
-- firmware-realtek
-- grub-pc-bin
-- grub-efi-amd64-bin
-- htop
-- ifstat
-- nvidia-kernel-dkms
-- nslcd
-- nvidia-container-toolkit
-- nvidia-smi
-- openzfs
-- open-vm-tools
-- libnvidia-encode1
-- linux-cpupower
-- truenas-samba
-- nfs4xdr-acl-tools
-- nfs4-acl-tools
-- qemu-guest-agent
-- scst-dbg
-- squashfs-tools
-- sysstat
-- truenas
+- name: dosfstools
+  install_recommends: true
+- name: linux-truenas-production-libc-dev
+  install_recommends: true
+- name: linux-headers-truenas-production-amd64
+  install_recommends: true
+- name: linux-headers-truenas-debug-amd64
+  install_recommends: true
+- name: linux-image-truenas-production-amd64
+  install_recommends: true
+- name: linux-image-truenas-debug-amd64
+  install_recommends: true
+- name: linux-perf-truenas
+  install_recommends: true
+- name: avahi-daemon
+  install_recommends: true
+- name: avahi-utils
+  install_recommends: true
+- name: nfs-kernel-server
+  install_recommends: true
+- name: bpftrace
+  install_recommends: true
+- name: bpfcc-tools
+  install_recommends: true
+- name: firmware-bnx2
+  install_recommends: true
+- name: firmware-bnx2x
+  install_recommends: true
+- name: firmware-cavium
+  install_recommends: true
+- name: firmware-linux
+  install_recommends: true
+- name: firmware-myricom
+  install_recommends: true
+- name: firmware-netronome
+  install_recommends: true
+- name: firmware-netxen
+  install_recommends: true
+- name: firmware-qlogic
+  install_recommends: true
+- name: firmware-realtek
+  install_recommends: true
+- name: grub-pc-bin
+  install_recommends: true
+- name: grub-efi-amd64-bin
+  install_recommends: true
+- name: htop
+  install_recommends: true
+- name: ifstat
+  install_recommends: true
+- name: nvidia-kernel-dkms
+  install_recommends: true
+- name: nslcd
+  install_recommends: true
+- name: nvidia-container-toolkit
+  install_recommends: true
+- name: nvidia-smi
+  install_recommends: true
+- name: openzfs
+  install_recommends: true
+- name: open-vm-tools
+  install_recommends: true
+- name: libnvidia-encode1
+  install_recommends: true
+- name: linux-cpupower
+  install_recommends: true
+- name: truenas-samba
+  install_recommends: true
+- name: nfs4xdr-acl-tools
+  install_recommends: true
+- name: nfs4-acl-tools
+  install_recommends: true
+- name: qemu-guest-agent
+  install_recommends: true
+- name: scst-dbg
+  install_recommends: true
+- name: squashfs-tools
+  install_recommends: true
+- name: sysstat
+  install_recommends: true
+- name: truenas
+  install_recommends: true
 - name: wireguard-tools
   install_recommends: false
-- openzfs-zfs-modules-dbg
-- openzfs-zfs-test
-- openzfs-zfs-initramfs
-- nvme-cli
-- convmv
-- open-iscsi
+- name: openzfs-zfs-modules-dbg
+  install_recommends: true
+- name: openzfs-zfs-test
+  install_recommends: true
+- name: openzfs-zfs-initramfs
+  install_recommends: true
+- name: nvme-cli
+  install_recommends: true
+- name: convmv
+  install_recommends: true
+- name: open-iscsi
+  install_recommends: true
 
 #
 # Packages which are removed from the base TrueNAS SCALE System by default

--- a/conf/build.manifest
+++ b/conf/build.manifest
@@ -203,61 +203,61 @@ apt_preferences:
 # NOTE: Installed in the order listed
 ############################################################################
 additional-packages:
-- package: xtail
+- name: xtail
   comment: used by support (NAS-108788)
   install_recommends: true
-- package: iperf3
+- name: iperf3
   comment: requested by sales (NAS-108787)
   install_recommends: true
-- package: fio
+- name: fio
   comment: requested by sales (NAS-108787)
   install_recommends: true
-- package: dnsutils
+- name: dnsutils
   comment: requested by community (NAS-109391)
   install_recommends: true
-- package: traceroute
+- name: traceroute
   comment: requested by platform and perf (NAS-110493)
   install_recommends: true
-- package: openseachest
+- name: openseachest
   comment: requested by performance team (NAS-106154)
   install_recommends: true
-- package: cxgbtool
+- name: cxgbtool
   comment: requested by OS team (NAS-111041)
   install_recommends: true
-- package: python-is-python3
+- name: python-is-python3
   comment: NAS-111358 (symlinks /usr/bin/python to python3)
   install_recommends: true
-- package: sdparm
+- name: sdparm
   comment: NAS-114723
   install_recommends: true
-- package: powertop
+- name: powertop
   comment: requested by community (NAS-113898)
   install_recommends: true
-- package: pv
+- name: pv
   comment: requested by community (NAS-115638)
   install_recommends: true
-- package: ndctl
+- name: ndctl
   comment: requested by community (NAS-108490)
   install_recommends: true
-- package: ipmctl
+- name: ipmctl
   comment: requested by community (NAS-108490)
   install_recommends: true
-- package: acpica-tools
+- name: acpica-tools
   comment: requested by platform team (NAS-118432)
   install_recommends: true
-- package: freeipmi
+- name: freeipmi
   comment: requested by engineering (NAS-121050)
   install_recommends: true
-- package: cu
+- name: cu
   comment: requested by platform team (NAS-120155)
   install_recommends: true
-- package: lrzsz
+- name: lrzsz
   comment: requested by platform team (NAS-120155)
   install_recommends: true
-- package: minicom
+- name: minicom
   comment: requested by platform team (NAS-120155)
   install_recommends: true
-- package: i2c-tools
+- name: i2c-tools
   comment: requested by platform team (NAS-120155)
   install_recommends: true
 

--- a/conf/build.manifest
+++ b/conf/build.manifest
@@ -85,6 +85,8 @@ base-packages:
 - squashfs-tools
 - sysstat
 - truenas
+- name: wireguard-tools
+  install_recommends: false
 - openzfs-zfs-modules-dbg
 - openzfs-zfs-test
 - openzfs-zfs-initramfs

--- a/scale_build/image/update.py
+++ b/scale_build/image/update.py
@@ -89,7 +89,7 @@ def install_rootfs_packages_impl():
             package = package_entry['name']
             install_recommends = package_entry.get('install_recommends', True)
 
-        logger.debug('Installing %r', package)
+        logger.debug('Installing %r%s', package, '' if install_recommends else ' (no recommends)')
         run_in_chroot(
             ['apt', 'install', '-V'] + (['--no-install-recommends'] if not install_recommends else []) + ['-y', package]
         )

--- a/scale_build/image/update.py
+++ b/scale_build/image/update.py
@@ -79,11 +79,20 @@ def install_rootfs_packages_impl():
     run_in_chroot(['apt', 'update'])
 
     manifest = get_manifest()
-    for package in itertools.chain(
+    for package_entry in itertools.chain(
         manifest['base-packages'], map(lambda d: d['package'], manifest['additional-packages'])
     ):
+        if isinstance(package_entry, str):
+            package = package_entry
+            install_recommends = True
+        else:
+            package = package_entry['name']
+            install_recommends = package_entry.get('install_recommends', True)
+
         logger.debug('Installing %r', package)
-        run_in_chroot(['apt', 'install', '-V', '-y', package])
+        run_in_chroot(
+            ['apt', 'install', '-V'] + (['--no-install-recommends'] if not install_recommends else []) + ['-y', package]
+        )
 
     # Do any custom rootfs setup
     custom_rootfs_setup()

--- a/scale_build/utils/manifest.py
+++ b/scale_build/utils/manifest.py
@@ -13,6 +13,7 @@ from scale_build.utils.paths import MANIFEST
 BRANCH_REGEX = re.compile(r'(branch\s*:\s*)\b[\w/\.-]+\b')
 SSH_SOURCE_REGEX = re.compile(r'^[\w]+@(\w.+):(\w.+)')
 
+
 INDIVIDUAL_REPO_SCHEMA = {
     'type': 'object',
     'properties': {
@@ -100,7 +101,20 @@ MANIFEST_SCHEMA = {
         },
         'base-packages': {
             'type': 'array',
-            'items': [{'type': 'string'}],
+            'items': {
+                'oneOf': [
+                    {'type': 'string'},
+                    {
+                        'type': 'object',
+                        'properties': {
+                            'install_recommends': {'type': 'boolean'},
+                            'name': {'type': 'string'},
+                        },
+                        'required': ['install_recommends', 'name'],
+                        'additionalProperties': False,
+                    },
+                ],
+            },
         },
         'base-prune': {
             'type': 'array',

--- a/scale_build/utils/manifest.py
+++ b/scale_build/utils/manifest.py
@@ -132,7 +132,7 @@ MANIFEST_SCHEMA = {
             'items': [{
                 'type': 'object',
                 'properties': {
-                    'package': {'type': 'string'},
+                    'name': {'type': 'string'},
                     'comment': {'type': 'string'},
                     'install_recommends': {'type': 'boolean'},
                 },

--- a/scale_build/utils/manifest.py
+++ b/scale_build/utils/manifest.py
@@ -134,8 +134,10 @@ MANIFEST_SCHEMA = {
                 'properties': {
                     'package': {'type': 'string'},
                     'comment': {'type': 'string'},
+                    'install_recommends': {'type': 'boolean'},
                 },
-                'required': ['package', 'comment'],
+                'required': ['package', 'comment', 'install_recommends'],
+                'additionalProperties': False,
             }]
         },
         'iso-packages': {

--- a/scale_build/utils/manifest.py
+++ b/scale_build/utils/manifest.py
@@ -136,7 +136,7 @@ MANIFEST_SCHEMA = {
                     'comment': {'type': 'string'},
                     'install_recommends': {'type': 'boolean'},
                 },
-                'required': ['package', 'comment', 'install_recommends'],
+                'required': ['name', 'comment', 'install_recommends'],
                 'additionalProperties': False,
             }]
         },

--- a/scale_build/utils/manifest.py
+++ b/scale_build/utils/manifest.py
@@ -100,20 +100,15 @@ MANIFEST_SCHEMA = {
         },
         'base-packages': {
             'type': 'array',
-            'items': {
-                'oneOf': [
-                    {'type': 'string'},
-                    {
-                        'type': 'object',
-                        'properties': {
-                            'install_recommends': {'type': 'boolean'},
-                            'name': {'type': 'string'},
-                        },
-                        'required': ['install_recommends', 'name'],
-                        'additionalProperties': False,
-                    },
-                ],
-            },
+            'items': [{
+                'type': 'object',
+                'properties': {
+                    'install_recommends': {'type': 'boolean'},
+                    'name': {'type': 'string'},
+                },
+                'required': ['install_recommends', 'name'],
+                'additionalProperties': False,
+            }],
         },
         'base-prune': {
             'type': 'array',

--- a/scale_build/utils/manifest.py
+++ b/scale_build/utils/manifest.py
@@ -13,7 +13,6 @@ from scale_build.utils.paths import MANIFEST
 BRANCH_REGEX = re.compile(r'(branch\s*:\s*)\b[\w/\.-]+\b')
 SSH_SOURCE_REGEX = re.compile(r'^[\w]+@(\w.+):(\w.+)')
 
-
 INDIVIDUAL_REPO_SCHEMA = {
     'type': 'object',
     'properties': {


### PR DESCRIPTION
This PR adds changes to allow us to not install recommended packages of some package. Right now we default to assuming that each package wants recommended packages to be installed however we can move ahead with the pruning slowly and have a default where recommended packages are not brought in by default and only in some cases where it is required we can bring those in.

We also fix truecommand here as it is not functional atm because of `wireguard-tools` package missing and if we install its recommended packages it brings in `wireguard-dkms` which we don't want as then it starts pulling upstream linux kernel headers.