### PR TITLE
NAS-122361 / 23.10 / Revert "Bring back upstream gluster mirror"

### DIFF
--- a/conf/build.manifest
+++ b/conf/build.manifest
@@ -12,10 +12,6 @@ apt-repos:
   distribution: bookworm
   components: main
   additional:
-  - url: http://apt.tn.ixsystems.com/apt-direct/cobia/nightlies/gluster/
-    distribution: bookworm
-    component: main
-    key: keys/gluster.gpg
   - url: http://apt.tn.ixsystems.com/apt-direct/cobia/nightlies/libnvidia/
     distribution: bookworm
     component: main


### PR DESCRIPTION
This reverts commit ff30d75257afba7c4589c25c049b3151e05a1805.