### PR TITLE
NAS-121173 / 23.10 / Use 2debug when building scst-dbg

### DIFF
--- a/conf/build.manifest
+++ b/conf/build.manifest
@@ -470,6 +470,7 @@ sources:
       env:
         KVER: "$(shell apt info linux-headers-truenas-debug-amd64 | awk '/Source:/ { print $$2}' | sed 's/linux-//')"
         KDIR: "/lib/modules/$(KVER)/build"
+        PKG_BUILD_MODE: 2debug
       depscmd:
         - "cat debian/control.dbgmodules > debian/control"
       prebuildcmd:


### PR DESCRIPTION
Prior to this change the `2debug` was **not** taking effect:
```
root@scale1[~]# uname -a
Linux scale1 6.1.24-debug+truenas #2 SMP PREEMPT_DYNAMIC Wed Jun  7 23:04:50 UTC 2023 x86_64 GNU/Linux
root@scale1[~]# cat /sys/kernel/scst_tgt/version
3.8.0-pre (revision=)
TRACING
root@scale1[~]# echo all > /sys/kernel/scst_tgt/trace_level
root@scale1[~]# dmesg
[ 2090.661357] [6401]: scst: scst_write_trace:304:Changed trace level for "scst": old 0x00002508, new 0xffffffff
root@scale1[~]# cat /sys/kernel/scst_tgt/version
3.8.0-pre (revision=)
TRACING
root@scale1[~]# dmesg
[ 2090.661357] [6401]: scst: scst_write_trace:304:Changed trace level for "scst": old 0x00002508, new 0xffffffff
root@scale1[~]#
```
(note the absence of DEBUG in _/sys/kernel/scst_tgt/version_)


With this change, it does:
```
root@scale1[~]# dmesg -c > /dev/null
root@scale1[~]# cat /sys/kernel/scst_tgt/version
3.8.0-pre (revision=)
EXTRACHECKS
TRACING
DEBUG
root@scale1[~]# dmesg
root@scale1[~]# echo all > /sys/kernel/scst_tgt/trace_level
root@scale1[~]# dmesg -c
[  135.294451] [6404]: scst: scst_write_trace:304:Changed trace level for "scst": old 0x80002f0e, new 0xffffffff
[  135.294479] [6404]: EXIT scst_write_trace: 4
[  135.294486] [6404]: EXIT scst_main_trace_level_store: 4
root@scale1[~]# cat /sys/kernel/scst_tgt/version
3.8.0-pre (revision=)
EXTRACHECKS
TRACING
DEBUG
root@scale1[~]# dmesg -c
[  151.744414] [6703]: ENTRY scst_version_show
[  151.744428] [6703]: EXIT scst_version_show
root@scale1[~]#
```