### PR TITLE
Remove OpenZFS test suite from SCALE

### DIFF
--- a/conf/build.manifest
+++ b/conf/build.manifest
@@ -134,8 +134,6 @@ base-packages:
   install_recommends: false
 - name: openzfs-zfs-modules-dbg
   install_recommends: true
-- name: openzfs-zfs-test
-  install_recommends: true
 - name: openzfs-zfs-initramfs
   install_recommends: true
 - name: nvme-cli


### PR DESCRIPTION
This commit removes OpenZFS test suite from SCALE.