### PR TITLE
NAS-119538 / 23.10 / Add netdata user/group

### DIFF
--- a/conf/reference-files/etc/group
+++ b/conf/reference-files/etc/group
@@ -3,7 +3,7 @@ wheel:x:0:
 daemon:x:1:
 bin:x:2:
 sys:x:3:
-adm:x:4:
+adm:x:4:netdata
 tty:x:5:
 disk:x:6:
 lp:x:7:
@@ -85,3 +85,4 @@ tss:x:136:
 iperf3:x:137:
 _chrony:x:138:
 polkitd:x:998:
+netdata:x:997:

--- a/conf/reference-files/etc/passwd
+++ b/conf/reference-files/etc/passwd
@@ -52,3 +52,4 @@ tss:x:129:136:TPM software stack,,,:/var/lib/tpm:/bin/false
 iperf3:x:130:137::/nonexistent:/usr/sbin/nologin
 _chrony:x:131:138:Chrony daemon,,,:/var/lib/chrony:/usr/sbin/nologin
 polkitd:x:998:998:polkit:/nonexistent:/usr/sbin/nologin
+netdata:x:999:997::/var/lib/netdata:/bin/sh


### PR DESCRIPTION
## Problem

Netdata user/group if not added to reference files results in build failing.


## Solution

Update user/group reference files so that they correctly reflect the netdata user/group and this results in persistent uid/gid for netdata user in scale.