### PR TITLE
Add socat to allow port-forwarding

### DIFF
--- a/conf/build.manifest
+++ b/conf/build.manifest
@@ -273,6 +273,8 @@ additional-packages:
   comment: requested by platform team (NAS-120155)
 - package: i2c-tools
   comment: requested by platform team (NAS-120155)
+- name: socat
+  comment: requested by community (NAS-122785)
 
 #
 # List of additional packages installed into TrueNAS SCALE ISO file


### PR DESCRIPTION
Kubernetes port-foward (k3s kubect port-foward) needs `socat` to work. Otherwise an error like this will occur:
> E0704 11:17:00.298021  220736 portforward.go:406] an error occurred
> forwarding 8080 -> 8080: error forwarding port 8080 to pod
> b9936b4a19a6d7a1f1622c9fa5dba657355a494c901a7bade899858fb731a6a6,
> uid : **unable to do port forwarding: socat not found**
>
> E0704 11:17:00.298234  220736 portforward.go:234] lost connection to pod

By installing socat it becomes possible to forward traffic to Kubernetes/k3s services via a command like this:
> k3s kubectl port-forward service/argo-cd-argocd-server -n argo-cd
> 8080:443 --address=0.0.0.0

This change should resolve the bug I raised: https://ixsystems.atlassian.net/browse/NAS-122785