### PR TITLE
Remove build tools from rootfs

### DIFF
--- a/scale_build/bootstrap/bootstrapdir.py
+++ b/scale_build/bootstrap/bootstrapdir.py
@@ -145,10 +145,6 @@ class RootfsBootstrapDir(BootstrapDir):
     def cache_filename(self):
         return 'basechroot-rootfs.squashfs'
 
-    def after_extra_packages_installation_steps(self):
-        if self.installed_packages_in_cache_changed:
-            clean_packages()
-
     def debootstrap_debian(self):
         manifest = get_manifest()
         run(
@@ -172,9 +168,25 @@ class PackageBootstrapDir(RootfsBootstrapDir):
     def extra_packages_to_install(self):
         return ['build-essential', 'dh-make', 'devscripts', 'fakeroot']
 
+    def after_extra_packages_installation_steps(self):
+        if self.installed_packages_in_cache_changed:
+            clean_packages()
+
     @property
     def cache_filename(self):
         return 'basechroot-package.squashfs'
+
+    @property
+    def extra_cache_files(self):
+        return [self.saved_packages_file_path]
+
+    @property
+    def installed_packages_in_cache_changed(self):
+        return self.installed_packages_in_cache != self.get_packages()
+
+    def save_build_cache(self, installed_packages):
+        super().save_build_cache(installed_packages)
+        self.update_saved_packages_list(installed_packages)
 
 
 class CdromBootstrapDirectory(BootstrapDir):

--- a/scale_build/bootstrap/bootstrapdir.py
+++ b/scale_build/bootstrap/bootstrapdir.py
@@ -131,7 +131,7 @@ class BootstrapDir(CacheMixin, HashMixin):
             shutil.rmtree(self.chroot_basedir)
 
 
-class PackageBootstrapDirectory(BootstrapDir):
+class RootfsBootstrapDir(BootstrapDir):
 
     @property
     def deopts(self):
@@ -139,11 +139,11 @@ class PackageBootstrapDirectory(BootstrapDir):
 
     @property
     def extra_packages_to_install(self):
-        return ['build-essential', 'dh-make', 'devscripts', 'fakeroot']
+        return []
 
     @property
     def cache_filename(self):
-        return 'basechroot-package.squashfs'
+        return 'basechroot-rootfs.squashfs'
 
     def after_extra_packages_installation_steps(self):
         if self.installed_packages_in_cache_changed:
@@ -164,6 +164,17 @@ class PackageBootstrapDirectory(BootstrapDir):
                 os.path.join(self.chroot_basedir, reference_file)
             )
         run(['chroot', self.chroot_basedir, '/debootstrap/debootstrap', '--second-stage'])
+
+
+class PackageBootstrapDir(RootfsBootstrapDir):
+
+    @property
+    def extra_packages_to_install(self):
+        return ['build-essential', 'dh-make', 'devscripts', 'fakeroot']
+
+    @property
+    def cache_filename(self):
+        return 'basechroot-package.squashfs'
 
 
 class CdromBootstrapDirectory(BootstrapDir):

--- a/scale_build/package.py
+++ b/scale_build/package.py
@@ -6,7 +6,7 @@ import threading
 
 from toposort import toposort
 
-from .bootstrap.bootstrapdir import PackageBootstrapDirectory
+from .bootstrap.bootstrapdir import PackageBootstrapDir
 from .clean import clean_bootstrap_logs
 from .config import PARALLEL_BUILD, PKG_DEBUG
 from .exceptions import CallError
@@ -109,7 +109,7 @@ def _build_packages_impl(desired_packages=None):
     logger.debug('Setting up bootstrap directory')
 
     with LoggingContext('build_packages', 'w'):
-        PackageBootstrapDirectory().setup()
+        PackageBootstrapDir().setup()
 
     logger.debug('Successfully setup bootstrap directory')
 

--- a/scale_build/packages/bootstrap.py
+++ b/scale_build/packages/bootstrap.py
@@ -1,6 +1,6 @@
 import os
 
-from scale_build.bootstrap.bootstrapdir import PackageBootstrapDirectory
+from scale_build.bootstrap.bootstrapdir import PackageBootstrapDir
 from scale_build.utils.run import run
 
 
@@ -10,4 +10,4 @@ class BootstrapMixin:
         os.makedirs(self.tmpfs_path, exist_ok=True)
         if self.tmpfs:
             run(['mount', '-t', 'tmpfs', '-o', f'size={self.tmpfs_size}G', 'tmpfs', self.tmpfs_path])
-        PackageBootstrapDirectory().restore_cache(self.chroot_base_directory)
+        PackageBootstrapDir().restore_cache(self.chroot_base_directory)

--- a/scale_build/update_image.py
+++ b/scale_build/update_image.py
@@ -2,7 +2,7 @@ import difflib
 import logging
 import os
 
-from .bootstrap.bootstrapdir import PackageBootstrapDirectory
+from .bootstrap.bootstrapdir import RootfsBootstrapDir
 from .exceptions import CallError
 from .image.bootstrap import (
     clean_mounts, setup_chroot_basedir, umount_chroot_basedir, umount_tmpfs_and_clean_chroot_dir
@@ -54,7 +54,7 @@ def build_update_image_impl():
     logger.debug('Bootstrapping TrueNAS rootfs [UPDATE] (%s/rootfs-bootstrap.log)', LOG_DIR)
 
     with LoggingContext('rootfs-bootstrap', 'w'):
-        package_bootstrap_obj = PackageBootstrapDirectory()
+        package_bootstrap_obj = RootfsBootstrapDir()
         package_bootstrap_obj.setup()
 
     logger.debug('Installing TrueNAS rootfs package [UPDATE] (%s/rootfs-packages.log)', LOG_DIR)


### PR DESCRIPTION
A rootfs image was used for package builder (where build tools are needed) and then it was reused for building the NAS rootfs image. Having them separate reduces the image size by about 150 megabytes. TrueNAS does not have gcc installed anymore.