### PR TITLE
NAS-123275 / 23.10 / Revert "NAS-122119 / use LD_LIBRARY_PATH when installing / upgrading

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -9,7 +9,7 @@ pexpect==4.8.0
 psutil==5.8.0
 ptyprocess==0.7.0
 pyparsing==3.0.9
-PyYAML==5.4.1
+PyYAML==6.0.1
 requests==2.31.0
 toposort==1.6
 urllib3==1.26.5

--- a/truenas_install/__main__.py
+++ b/truenas_install/__main__.py
@@ -31,9 +31,6 @@ RE_UNSQUASHFS_PROGRESS = re.compile(r"\[.+\]\s+(?P<extracted>[0-9]+)/(?P<total>[
 run_kw = dict(check=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE, encoding="utf-8", errors="ignore")
 
 IS_FREEBSD = platform.system().upper() == "FREEBSD"
-LD_LOAD_PATHS = [
-    '/usr/lib/x86_64-linux-gnu'
-]
 is_json_output = False
 
 
@@ -557,14 +554,7 @@ def main():
                             if old_bootfs_prop != "-":
                                 run_command(["zfs", "set", "truenas:12=1", old_bootfs_prop])
 
-                        for p in LD_LOAD_PATHS:
-                            if not os.path.exists(f'{root}/{p}'):
-                                write_error(f"{root}/{p}: library path does not exist.", raise_=True)
-
-                        write_progress(0.6, "Preparing initramfs configuration")
-                        os.environ['LD_LIBRARY_PATH'] = ':'.join([f'{root}/{p}' for p in LD_LOAD_PATHS])
                         cp = run_command([f"{root}/usr/local/bin/truenas-initrd.py", root], check=False)
-                        os.environ.pop('LD_LIBRARY_PATH', None)
                         if cp.returncode > 1:
                             raise subprocess.CalledProcessError(
                                 cp.returncode, f'Failed to execute truenas-initrd: {cp.stderr}'


### PR DESCRIPTION
This reverts commit 0b7cf5806976e94fb105613537f196598c37a5f6.

Unfortunately, for reasons not understood, this is causing `truenas-initrd.py` in the upgrade image to core dump. Reverting this commit fixes the issue. There will be a subsequent commit to fix the issue this tried to fix in the first place. (Failing to import libraries on fresh install)