### PR TITLE
NAS-123615 / 23.10 / Fix makefile not able to setup virtualenv (by sonicaj)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@ check:
 ifneq ($(REPO_CHANGED),0)
 	@echo "Setting up new virtual environment"
 	@rm -rf venv-*
-	@${PYTHON} -m pip install -U virtualenv >/dev/null || { echo "Failed to install/upgrade virtualenv package"; exit 1; }
+	@${PYTHON} -m pip install --break-system-packages -U virtualenv >/dev/null || { echo "Failed to install/upgrade virtualenv package"; exit 1; }
 	@${PYTHON} -m venv venv-${COMMIT_HASH} || { echo "Failed to create virutal environment"; exit 1; }
 	@{ . ./venv-${COMMIT_HASH}/bin/activate && \
 		python3 -m pip install -r requirements.txt >/dev/null 2>&1 && \


### PR DESCRIPTION
This commit adds a fix which makes sure the makefile is able to setup virtualenv for scale builder execution as stable debian release now does not allow setting it up unless user explicitly specifies it.

Original PR: https://github.com/truenas/scale-build/pull/483
Jira URL: https://ixsystems.atlassian.net/browse/NAS-123615