### PR TITLE
NAS-124055 / 24.04 / Implement dataset-based filesystem hierarchy

### DIFF
--- a/scale_build/image/update.py
+++ b/scale_build/image/update.py
@@ -160,6 +160,13 @@ def custom_rootfs_setup():
     shutil.rmtree(tmp_systemd)
     run_in_chroot(['depmod'], check=False)
 
+    # /usr will be readonly and so we want the ca-certificates directory to
+    # symlink to writeable location in /var/local
+    local_cacerts = os.path.join(CHROOT_BASEDIR, "usr/local/share/ca-certificates")
+    os.makedirs(os.path.join(CHROOT_BASEDIR, "usr/local/share"), exist_ok=True)
+    shutil.rmtree(local_cacerts, ignore_errors=True)
+    os.symlink("/var/local/ca-certificates", local_cacerts)
+
 
 def clean_rootfs():
     to_remove = get_manifest()['base-prune']

--- a/scale_build/main.py
+++ b/scale_build/main.py
@@ -69,7 +69,7 @@ def main():
     )
 
     validate_parser = subparsers.add_parser('validate', help='Validate TrueNAS Scale build manifest and system state')
-    for action in ('manifest', 'system_state'):
+    for action in ('datasets', 'manifest', 'system_state'):
         validate_parser.add_argument(f'--validate-{action}', dest=action, action='store_true')
         validate_parser.add_argument(f'--no-validate-{action}', dest=action, action='store_false')
         validate_parser.set_defaults(**{action: True})
@@ -93,7 +93,7 @@ def main():
     elif args.action == 'clean':
         complete_cleanup()
     elif args.action == 'validate':
-        validate(args.system_state, args.manifest)
+        validate(args.system_state, args.manifest, args.datasets)
     elif args.action == 'branchout':
         validate_branch_out_config(not args.skip_push)
         branch_out_repos(not args.skip_push)

--- a/scale_build/validate.py
+++ b/scale_build/validate.py
@@ -1,9 +1,11 @@
 import os
+import jsonschema
 import logging
 import shutil
 
 from .exceptions import CallError, MissingPackagesException
 from .utils.manifest import validate_manifest
+from truenas_install import fhs
 
 
 logger = logging.getLogger(__name__)
@@ -31,10 +33,18 @@ def validate_system_state():
         raise MissingPackagesException(missing_packages)
 
 
-def validate(system_state_flag=True, manifest_flag=True):
+def validate_datasets():
+    jsonschema.validate(fhs.TRUENAS_DATASETS, fhs.TRUENAS_DATASET_SCHEMA)
+
+
+def validate(system_state_flag=True, manifest_flag=True, datasets_flag=True):
     if system_state_flag:
         validate_system_state()
         logger.debug('System state Validated')
     if manifest_flag:
         validate_manifest()
         logger.debug('Manifest Validated')
+
+    if datasets_flag:
+        validate_datasets()
+        logger.debug('Dataset schema Validated')

--- a/scale_build/validate.py
+++ b/scale_build/validate.py
@@ -34,7 +34,10 @@ def validate_system_state():
 
 
 def validate_datasets():
-    jsonschema.validate(fhs.TRUENAS_DATASETS, fhs.TRUENAS_DATASET_SCHEMA)
+    try:
+        jsonschema.validate(fhs.TRUENAS_DATASETS, fhs.TRUENAS_DATASET_SCHEMA)
+    except jsonschema.ValidationError as e:
+        raise CallError(f'Provided dataset schema is invalid: {e}')
 
 
 def validate(system_state_flag=True, manifest_flag=True, datasets_flag=True):

--- a/truenas_install/fhs.py
+++ b/truenas_install/fhs.py
@@ -17,7 +17,7 @@ The following keys are supported:
          name related components
 `options` - Dataset configuration options (explained below)
 `mode` - permissions to set on the dataset's mountpoint during installation
-`mp` - dataset mountpoint.
+`mountpoint` - dataset mountpoint.
 `snap` - Take a snapshot named "pristine" after creating the dataset.
 
 OPTIONS
@@ -96,7 +96,7 @@ TRUENAS_DATASETS = [
     {
         'name':  'var/ca-certificates',
         'options': ['NOSUID', 'NOACL', 'NOEXEC'],
-        'mp': '/var/local/ca-certificates'
+        'mountpoint': '/var/local/ca-certificates'
     },
     {
         'name':  'var/log',

--- a/truenas_install/fhs.py
+++ b/truenas_install/fhs.py
@@ -13,12 +13,16 @@ present.
 KEYS
 --------------
 The following keys are supported:
-`name` - the name of the dataset (will be appended to other dataset
-         name related components
-`options` - Dataset configuration options (explained below)
+`name` - the name of the dataset (will be appended to other dataset name
+    related components
+`options` - Dataset configuration options (explained below). There is no
+    default.
 `mode` - permissions to set on the dataset's mountpoint during installation
-`mountpoint` - dataset mountpoint.
+    default is 0o755
+`mountpoint` - dataset mountpoint. If no mountpoint is specified then it
+    /`name` will be assumed.
 `snap` - Take a snapshot named "pristine" after creating the dataset.
+    default is False
 
 OPTIONS
 --------------
@@ -46,6 +50,41 @@ var/log - separate dataset for system logs. This is to provide flexibility to
 var/ca-certificates - administrator-provided CA certificates, symlinked
     from /usr/local/share/ca-certificates.
 """
+
+
+# Following schema is used for validation (e.g. "make validate") in scale-build
+# If any changes are made to OPTIONS or KEYS above then schema must be updated
+# accordingly.
+TRUENAS_DATASET_SCHEMA = {
+    'type': 'array',
+    'items': {
+    'type': 'object',
+        'properties': {
+            'name': {'type': 'string'},
+            'options': {
+                'type': 'array',
+                'items': {
+                    'type': 'string',
+                    'enum': [
+                        'NOSUID',
+                        'NOEXEC',
+                        'NOACL',
+                        'NOATIME',
+                        'RO',
+                        'NODEV',
+                    ]
+                },
+                'uniqueItems': True,
+            },
+            'mode': {'type': 'integer'},
+            'mountpoint': {'type': 'string'},
+            'snap': {'type': 'boolean'},
+        },
+        'required': ['name', 'options'],
+        'additionalProperties': False,
+    }
+}
+
 
 TRUENAS_DATASETS = [
     {

--- a/truenas_install/fhs.py
+++ b/truenas_install/fhs.py
@@ -58,7 +58,7 @@ var/ca-certificates - administrator-provided CA certificates, symlinked
 TRUENAS_DATASET_SCHEMA = {
     'type': 'array',
     'items': {
-    'type': 'object',
+        'type': 'object',
         'properties': {
             'name': {'type': 'string'},
             'options': {

--- a/truenas_install/fhs.py
+++ b/truenas_install/fhs.py
@@ -1,0 +1,105 @@
+"""
+TrueNAS Filesysten Heirarchy Standards extensions
+
+The TRUENAS_DATASET dictionary contains the dataset configuration
+settings for the root filesystem of the truenas server.
+
+When practical it is best to turn off unnecessary features.
+For example, disabling ACL support on system files simplifies
+permissions auditing. Disabling ACL support also ensures compliance
+with STIGs that require configuration files and libraries to not have ACLs
+present.
+
+KEYS
+--------------
+The following keys are supported:
+`name` - the name of the dataset (will be appended to other dataset
+         name related components
+`options` - Dataset configuration options (explained below)
+`mode` - permissions to set on the dataset's mountpoint during installation
+`mp` - dataset mountpoint.
+`snap` - Take a snapshot named "pristine" after creating the dataset.
+
+OPTIONS
+--------------
+NOSUID - sets a combination of setuid=off and devices=off
+NOEXEC - sets exec=off
+NOACL - sets acltype=off.
+NOATIME - sets atime=off.
+RO - sets readonly=on.
+NODEV - sets devices=off
+
+DATASETS
+--------------
+audit - dataset used for storing system auditing databases
+conf - truenas configuration files - static
+data - truenas configuraiton files - dynamic
+etc - see FHS
+home - see FHS, NOTE: only `admin` account will be present
+mnt - TrueNAS does not follow FHS for this path. It is reserved exclusively
+    for ZFS pool mountpoints.
+opt - see FHS
+usr - see FHS
+var - see FHS
+var/log - separate dataset for system logs. This is to provide flexibility to
+    snapshot and replicate log information as needed by administrator.
+var/ca-certificates - administrator-provided CA certificates, symlinked
+    from /usr/local/share/ca-certificates.
+"""
+
+TRUENAS_DATASETS = [
+    {
+        'name':  'audit',
+        'options': ['NOSUID', 'NOEXEC', 'NOATIME', 'NOACL'],
+        'mode': 0o700
+    },
+    {
+        'name':  'conf',
+        'options': ['NOSUID', 'NOEXEC', 'RO', 'NOACL'],
+        'mode': 0o700,
+        'snap': True
+    },
+    {
+        'name':  'data',
+        'options': ['NOSUID', 'NOEXEC', 'NOACL', 'NOATIME'],
+        'mode': 0o700,
+        'snap': True
+    },
+    {
+        'name':  'mnt',
+        'options': ['NOSUID', 'NOEXEC', 'NOACL', 'NOATIME'],
+    },
+    {
+        'name':  'etc',
+        'options': ['NOSUID', 'NOACL', 'NOEXEC'],
+        'snap': True
+    },
+    {
+        'name':  'home',
+        'options': ['NOSUID', 'NOACL', 'NOEXEC']
+    },
+    {
+        'name':  'opt',
+        'options': ['NOSUID', 'NOACL'],
+        'snap': True
+    },
+    {
+        'name':  'usr',
+        'options': ['NOSUID', 'NOACL', 'RO', 'NOATIME'],
+        'snap': True
+    },
+    {
+        'name':  'var',
+        'options': ['NOSUID', 'NOACL', 'NOATIME'],
+        'snap': True
+    },
+    {
+        'name':  'var/ca-certificates',
+        'options': ['NOSUID', 'NOACL', 'NOEXEC'],
+        'mp': '/var/local/ca-certificates'
+    },
+    {
+        'name':  'var/log',
+        'options': ['NOSUID', 'NOEXEC', 'NOACL', 'NOATIME']
+    },
+]


### PR DESCRIPTION
Create filesystem hierarchy for new boot environments based
on specifications in fhs.py file in truenas_install directory.

This gives us more flexibility regarding which parts of FS to
make readonly, and also identifying precise local changes from
a pristine environment that users have made to system files.

Precise settings detailed in comments in the specification file.
Overall, this gives better posture for STIG compliance regarding
auditability and prevention of unauthorized OS changes.