### PR TITLE
NAS-124338 / 24.04 / Make rootfs readonly

### DIFF
--- a/truenas_install/__main__.py
+++ b/truenas_install/__main__.py
@@ -702,6 +702,9 @@ def main():
             run_command(["zfs", "set", f"mountpoint={mp}", this_ds])
             run_command(["zfs", "set", 'org.zectl:bootloader=""', this_ds])
 
+        run_command(["zfs", "set", "readonly=on", dataset_name])
+        run_command(["zfs", "snapshot", f"{dataset_name}@pristine"])
+
     except Exception:
         if old_bootfs_prop != "-":
             run_command(["zpool", "set", f"bootfs={old_bootfs_prop}", pool_name])

--- a/truenas_install/fhs.py
+++ b/truenas_install/fhs.py
@@ -119,7 +119,13 @@ TRUENAS_DATASETS = [
     },
     {
         'name':  'opt',
+        'options': ['NOSUID', 'NOACL', 'RO'],
+        'snap': True
+    },
+    {
+        'name':  'root',
         'options': ['NOSUID', 'NOACL'],
+        'mode': 0o700,
         'snap': True
     },
     {


### PR DESCRIPTION
This PR expands existing fhs setup to make `/`  and `/opt` readonly, and make `/root` a separate dataset. 