### PR TITLE
NAS-124479 / 24.04 / rsync home dir to new boot environment on upgrade

### DIFF
--- a/truenas_install/__main__.py
+++ b/truenas_install/__main__.py
@@ -494,6 +494,7 @@ def main():
                     rsync = [
                         "etc/hostid",
                         "data",
+                        "home",
                         "root",
                     ]
                     if is_freebsd_upgrade:


### PR DESCRIPTION
We now store SSH keys for admin user in /home and so we should preserve it on upgrades.