### PR TITLE
NAS-124479 / 23.10.0 / rsync home dir to new boot environment on upgrade (by anodos325)

### DIFF
--- a/truenas_install/__main__.py
+++ b/truenas_install/__main__.py
@@ -453,6 +453,7 @@ def main():
                     rsync = [
                         "etc/hostid",
                         "data",
+                        "home",
                         "root",
                     ]
                     if is_freebsd_upgrade:


### PR DESCRIPTION
We now store SSH keys for admin user in /home and so we should preserve it on upgrades.

Original PR: https://github.com/truenas/scale-build/pull/504
Jira URL: https://ixsystems.atlassian.net/browse/NAS-124479