### PR TITLE
NAS-124646 / 23.10.0 / Fix upgrade path from Core to SCALE (by anodos325)

### DIFF
--- a/truenas_install/__main__.py
+++ b/truenas_install/__main__.py
@@ -453,14 +453,16 @@ def main():
                     rsync = [
                         "etc/hostid",
                         "data",
-                        "home",
                         "root",
                     ]
                     if is_freebsd_upgrade:
                         if not IS_FREEBSD:
                             setup_machine_id = True
                     else:
-                        rsync.append("etc/machine-id")
+                        rsync.extend([
+                            "etc/machine-id",
+                            "home"
+                        ])
 
                     run_command([
                         "rsync", "-aRx",


### PR DESCRIPTION
TrueNAS Core installs by default do not have a /home directory and so it should be omitted when copying data to new boot environment on that platform. No attempt is made to copy a non-default /home configuration because that directory is used in SCALE and may cause undesired behavior post-upgrade.

Original PR: https://github.com/truenas/scale-build/pull/512
Jira URL: https://ixsystems.atlassian.net/browse/NAS-124646