### PR TITLE
NAS-124675 / 24.04 / Fix make clean

### DIFF
--- a/scale_build/clean.py
+++ b/scale_build/clean.py
@@ -9,15 +9,20 @@ logger = logging.getLogger(__name__)
 
 
 def clean_bootstrap_logs():
-    for f in filter(lambda f: f.startswith('bootstrap'), os.listdir(LOG_DIR)):
-        os.unlink(os.path.join(LOG_DIR, f))
+    with os.scandir(LOG_DIR) as logdir:
+        for i in logdir:
+            if i.is_file() and i.name.startswith('bootstrap'):
+                os.unlink(i.path)
 
 
 def clean_packages():
-    for d in (HASH_DIR, PKG_DIR):
-        if os.path.exists(d):
-            shutil.rmtree(d)
-        os.makedirs(d)
+    for path in (HASH_DIR, PKG_DIR):
+        try:
+            shutil.rmtree(path)
+        except OSError:
+            continue
+        else:
+            os.makedirs(path)
 
 
 def complete_cleanup():

--- a/scale_build/clean.py
+++ b/scale_build/clean.py
@@ -21,7 +21,26 @@ def clean_packages():
 
 
 def complete_cleanup():
-    for path in filter(os.path.exists, (LOG_DIR, SOURCES_DIR, TMP_DIR)):
-        shutil.rmtree(path)
+    for path in (LOG_DIR, SOURCES_DIR, TMP_DIR):
+        try:
+            shutil.rmtree(path)
+        except (FileNotFoundError, NotADirectoryError):
+            # these shouldn't happen but they're explicitly
+            # ignored so a comment can be made and you are
+            # able to gather context
+            continue
+        except OSError:
+            # we use a bunch of overlayfs mounts (using tmpfs) for
+            # each package that we build. if the build is interrupted
+            # for whatever reason (someone kills job in jenkins) then
+            # OSError can be raised with errno 66 (directory not empty)
+            # for example because the `TMP_DIR` can have a sub-directory
+            # that points back to an overlayfs mountpoint that has not
+            # been umounted (because build process was interrupted)
+            # In this case, we can safely ignore the errors and move on
+            # because the next time our build process is kicked off, each
+            # package will call `delete_overlayfs()` which will clean this
+            # up for us
+            continue
 
     logger.debug('Removed %s, %s, and %s directories', LOG_DIR, SOURCES_DIR, TMP_DIR)


### PR DESCRIPTION
Working on the new CI/CD infrastructure, I've had to forcefully stop running builds. Depending on when the build is interrupted, overlayfs mounts are left behind on the system.

However, when we run `make clean` this fails because the directories that are trying to be removed are backed by the mounted overlayfs mounts. We can safely ignore these errors and move on because `make packages` will clean up any left over overlay mounts for each package.

Finally, use `os.scandir` because it's more efficient and remove `os.path.exists` calls that occur before performing file I/O since that's a theoretical race condition.