### PR TITLE
We should not be building inadyn anymore

### DIFF
--- a/conf/build.manifest
+++ b/conf/build.manifest
@@ -332,9 +332,6 @@ sources:
     - "./pull.sh"
   deoptions: nocheck
   generate_version: false
-- name: inadyn
-  branch: master
-  repo: https://github.com/truenas/inadyn.git
 - name: pyglfs
   branch: master
   repo: https://github.com/truenas/pyglfs.git

--- a/conf/reference-files/etc/group
+++ b/conf/reference-files/etc/group
@@ -60,7 +60,6 @@ ssl-cert:x:118:
 ntp:x:119:
 Debian-exim:x:120:
 tftp:x:121:
-debian-inadyn:x:122:
 tcpdump:x:123:
 rdma:x:124:
 gluster:x:125:

--- a/conf/reference-files/etc/passwd
+++ b/conf/reference-files/etc/passwd
@@ -33,7 +33,6 @@ Debian-snmp:x:113:117::/var/lib/snmp:/bin/false
 ntp:x:114:119::/nonexistent:/usr/sbin/nologin
 Debian-exim:x:115:120::/var/spool/exim4:/usr/sbin/nologin
 tftp:x:116:121:tftp daemon,,,:/srv/tftp:/usr/sbin/nologin
-debian-inadyn:x:117:122:inadyn dyndns client,,,:/run/inadyn:/bin/false
 tcpdump:x:118:123::/nonexistent:/usr/sbin/nologin
 gluster:x:119:125::/var/lib/glusterd:/usr/sbin/nologin
 proftpd:x:120:65534::/run/proftpd:/usr/sbin/nologin


### PR DESCRIPTION
This PR adds changes to not build inadyn any longer because it is no longer a service in SCALE and hence no reason to include it in the build (it was removed in https://github.com/truenas/middleware/pull/11403)