### PR TITLE
NAS-121831 / 24.04 / Make pkg_mgmt_disabled executable in post_rootfs_setup

### DIFF
--- a/scale_build/image/update.py
+++ b/scale_build/image/update.py
@@ -122,6 +122,12 @@ def post_rootfs_setup():
     with os.scandir(os.path.join(CHROOT_BASEDIR, 'usr/bin')) as binaries:
         for binary in filter(lambda x: should_rem_execute_bit(x), binaries):
             os.chmod(binary.path, stat.S_IMODE(binary.stat(follow_symlinks=False).st_mode) & no_executable_flag)
+    # Make pkg_mgmt_disabled executable
+    executable_flag = stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH
+    pkg_mgmt_disabled_path = os.path.join(CHROOT_BASEDIR, 'usr/local/bin/pkg_mgmt_disabled')
+    if os.path.isfile(pkg_mgmt_disabled_path):
+        old_mode = os.stat(pkg_mgmt_disabled_path).st_mode
+        os.chmod(pkg_mgmt_disabled_path, old_mode | executable_flag)
 
 
 def custom_rootfs_setup():


### PR DESCRIPTION
This cannot be done before, as it is being used to mask the `apt` executables.

(Corresponding middleware PR (#[12140](https://github.com/truenas/middleware/pull/12140)) is being held until this is merged.)