### PR TITLE
NAS-124677 / 23.10.1 / We should not be building inadyn anymore (by sonicaj)

### DIFF
--- a/conf/build.manifest
+++ b/conf/build.manifest
@@ -332,9 +332,6 @@ sources:
     - "./pull.sh"
   deoptions: nocheck
   generate_version: false
-- name: inadyn
-  branch: stable/cobia
-  repo: https://github.com/truenas/inadyn.git
 - name: pyglfs
   branch: stable/cobia
   repo: https://github.com/truenas/pyglfs.git

--- a/conf/reference-files/etc/group
+++ b/conf/reference-files/etc/group
@@ -60,7 +60,6 @@ ssl-cert:x:118:
 ntp:x:119:
 Debian-exim:x:120:
 tftp:x:121:
-debian-inadyn:x:122:
 tcpdump:x:123:
 rdma:x:124:
 gluster:x:125:

--- a/conf/reference-files/etc/passwd
+++ b/conf/reference-files/etc/passwd
@@ -33,7 +33,6 @@ Debian-snmp:x:113:117::/var/lib/snmp:/bin/false
 ntp:x:114:119::/nonexistent:/usr/sbin/nologin
 Debian-exim:x:115:120::/var/spool/exim4:/usr/sbin/nologin
 tftp:x:116:121:tftp daemon,,,:/srv/tftp:/usr/sbin/nologin
-debian-inadyn:x:117:122:inadyn dyndns client,,,:/run/inadyn:/bin/false
 tcpdump:x:118:123::/nonexistent:/usr/sbin/nologin
 gluster:x:119:125::/var/lib/glusterd:/usr/sbin/nologin
 proftpd:x:120:65534::/run/proftpd:/usr/sbin/nologin


### PR DESCRIPTION
Automatic cherry-pick failed. Please resolve conflicts by running:

    git reset --hard HEAD~1
    git cherry-pick -x 21f61c6a15f741c02f9788d3289e3013f96f1bd2
    git cherry-pick -x 2ac630a206e915e65cd8174edd7c27506bf3aee8

If the original PR was merged via a squash, you can just cherry-pick the squashed commit:

    git reset --hard HEAD~1
    git cherry-pick -x 114b4bb0061be65c2091fd16448859f65677b5fe

This PR adds changes to not build inadyn any longer because it is no longer a service in SCALE and hence no reason to include it in the build (it was removed in https://github.com/truenas/middleware/pull/11403)

Original PR: https://github.com/truenas/scale-build/pull/519
Jira URL: https://ixsystems.atlassian.net/browse/NAS-124677