### PR TITLE
NAS-124717 / 23.10.1 / Bump build epoch as group/passwd files have been changed (by sonicaj)

### DIFF
--- a/conf/build.manifest
+++ b/conf/build.manifest
@@ -175,7 +175,7 @@ base-prune:
 # Update build-epoch when you want to force the next build to be
 # non-incremental
 ############################################################################
-build-epoch: 9
+build-epoch: 10
 
 # Apt Preferences
 ############################################################################


### PR DESCRIPTION
Until we fix the issue where base chroot cache is not invalidated whenever group/passwd files are changed, let's bump build epoch to fix incrementals

Original PR: https://github.com/truenas/scale-build/pull/522
Jira URL: https://ixsystems.atlassian.net/browse/NAS-124717