### PR TITLE
NAS-125112 / 24.04 / Make /boot read-write

### DIFF
--- a/truenas_install/fhs.py
+++ b/truenas_install/fhs.py
@@ -93,6 +93,12 @@ TRUENAS_DATASETS = [
         'mode': 0o700
     },
     {
+        'name':  'boot',
+        'options': ['NOACL'],
+        'mode': 0o755,
+        'snap': True
+    },
+    {
         'name':  'cluster',
         'options': ['NOSUID', 'NOEXEC', 'NOATIME', 'NOACL'],
     },


### PR DESCRIPTION
Setting tunables and updating grub require writable /boot.