### PR TITLE
NAS-125238 / 24.04 / Use stable/dragonfish to relax half ARC limits for dragonfish nightlies

### DIFF
--- a/conf/build.manifest
+++ b/conf/build.manifest
@@ -387,7 +387,7 @@ sources:
 - name: openzfs
   repo: https://github.com/truenas/zfs
   batch_priority: 0
-  branch: truenas/zfs-2.2-release
+  branch: stable/dragonfish
   env:
     KVERS: "$(shell apt info linux-headers-truenas-production-amd64 | awk '/Source:/ { print $$2}' | sed 's/linux-//')"
     KSRC: "/usr/src/linux-headers-$(KVERS)"


### PR DESCRIPTION
https://github.com/truenas/zfs/pull/181