### PR TITLE
NAS-125230 / 23.10.1 / Update OpenZFS build to generate changelog

### DIFF
--- a/conf/build.manifest
+++ b/conf/build.manifest
@@ -397,6 +397,9 @@ sources:
     - "sed -i 's/libtool,/libtool, linux-image-truenas-production-amd64, linux-headers-truenas-production-amd64,/' debian/control"
   deps_path: contrib/debian
   prebuildcmd:
+    - "sh autogen.sh"
+    - "./configure"
+    - "cp contrib/debian/changelog debian/changelog"
     - "sed 's/@CFGOPTS@/--enable-debuginfo/g' debian/rules.in > debian/rules"
     - "chmod +x debian/rules"
   buildcmd:
@@ -419,6 +422,9 @@ sources:
         - "sed -i 's/libtool,/libtool, linux-image-truenas-debug-amd64, linux-headers-truenas-debug-amd64,/' debian/control"
       deps_path: contrib/debian
       prebuildcmd:
+        - "sh autogen.sh"
+        - "./configure"
+        - "cp contrib/debian/changelog debian/changelog"
         - "sed 's/@CFGOPTS@/--enable-debug --enable-debuginfo/g' debian/rules.in > debian/rules"
         - "chmod +x debian/rules"
         - "sed  -i 's/Provides: openzfs-zfs-modules/Provides: openzfs-zfs-modules-dbg/'  debian/control.modules.in"


### PR DESCRIPTION
Upstream ZFS has automated changelog generation with new version. This commit adapts to that change and generates changelog from configure.

This PR should be merged before https://github.com/truenas/zfs/pull/184 is merged.