### PR TITLE
NAS-125340 / 24.04 / Add nobody group, with the same gid as nogroup.

### DIFF
--- a/conf/reference-files/etc/group
+++ b/conf/reference-files/etc/group
@@ -39,6 +39,7 @@ staff:x:50:
 games:x:60:
 users:x:100:
 nogroup:x:65534:
+nobody:x:65534:
 systemd-timesync:x:101:
 systemd-journal:x:102:
 systemd-network:x:103:


### PR DESCRIPTION
This is in support of users upgrading from CORE.