### PR TITLE
NAS-125875 / 24.04 / Revert "Remove smartmontools fork" (Bump to 7.4-2 upstream)

### DIFF
--- a/conf/build.manifest
+++ b/conf/build.manifest
@@ -616,3 +616,12 @@ sources:
     - kernel
     - kernel-dbg
   generate_version: false
+- name: smartmontools
+  repo: https://github.com/truenas/smartmontools
+  branch: master
+  debian_fork: true
+  predepscmd:
+    - "apt install -y wget xz-utils"
+    - "./pull.sh"
+  deoptions: nocheck
+  generate_version: false


### PR DESCRIPTION
This reverts commit 1211f4a9f5e2d0eec66b40c984104ee015127823. The reason why this is being reverted is because I updated our local fork to pull in 7.4-2 (latest upstream at time of writing). This pulls in both of the local patches we pushed upstream but also fixes another issue that 1 of our SCALE users is experiencing. See https://github.com/truenas/smartmontools/pull/3 for details on bumping to 7.4-2.