### PR TITLE
NAS-125875 / 23.10.2 / Revert "Remove smartmontools fork"

### DIFF
--- a/conf/build.manifest
+++ b/conf/build.manifest
@@ -608,3 +608,12 @@ sources:
     - kernel
     - kernel-dbg
   generate_version: false
+- name: smartmontools
+  repo: https://github.com/truenas/smartmontools
+  branch: master
+  debian_fork: true
+  predepscmd:
+    - "apt install -y wget xz-utils"
+    - "./pull.sh"
+  deoptions: nocheck
+  generate_version: false


### PR DESCRIPTION
This reverts commit 1211f4a9f5e2d0eec66b40c984104ee015127823.

(cherry picked from commit 9df1eac2eb7e72f629fb847dcdae0093f7c55d6f)