### PR TITLE
NAS-125472 / 24.04 / Validate cached bootstrap directory based off on the reference group/passwd files

### DIFF
--- a/scale_build/bootstrap/cache.py
+++ b/scale_build/bootstrap/cache.py
@@ -66,6 +66,9 @@ class CacheMixin:
             else:
                 intact = False
 
+            # Remove the temporary restored cached directory
+            shutil.rmtree(self.chroot_basedir, ignore_errors=True)
+
         if not intact:
             self.remove_cache()
 

--- a/scale_build/bootstrap/cache.py
+++ b/scale_build/bootstrap/cache.py
@@ -56,15 +56,10 @@ class CacheMixin:
 
         if intact:
             self.restore_cache(self.chroot_basedir)
-            if os.path.exists(
-                os.path.join(self.chroot_basedir, 'etc/passwd')
-            ) and os.path.exists(os.path.join(self.chroot_basedir, 'etc/group')):
-                for _, diff in compare_reference_files(cut_nonexistent_user_group_membership=True):
-                    if diff:
-                        intact = False
-                        break
-            else:
-                intact = False
+            for _, diff in compare_reference_files(cut_nonexistent_user_group_membership=True):
+                if diff:
+                    intact = False
+                    break
 
             # Remove the temporary restored cached directory
             shutil.rmtree(self.chroot_basedir, ignore_errors=True)

--- a/scale_build/utils/reference_files.py
+++ b/scale_build/utils/reference_files.py
@@ -1,0 +1,29 @@
+import os
+import difflib
+
+from .paths import REFERENCE_FILES_DIR, REFERENCE_FILES, CHROOT_BASEDIR
+
+
+def compare_reference_files(cut_nonexistent_user_group_membership=False):
+    for reference_file in REFERENCE_FILES:
+        with open(os.path.join(REFERENCE_FILES_DIR, reference_file)) as f:
+            reference = f.readlines()
+
+        if cut_nonexistent_user_group_membership:
+            if reference_file == 'etc/group':
+                # `etc/group` on newly installed system can't have group membership information for users that have
+                # not been created yet.
+                with open(os.path.join(CHROOT_BASEDIR, 'etc/passwd')) as f:
+                    reference_users = {line.split(':')[0] for line in f.readlines()}
+
+                for i, line in enumerate(reference):
+                    bits = line.rstrip().split(':')
+                    bits[3] = ','.join([user for user in bits[3].split(',') if user in reference_users])
+                    reference[i] = ':'.join(bits) + '\n'
+
+        with open(os.path.join(CHROOT_BASEDIR, reference_file)) as f:
+            real = f.readlines()
+
+        diff = list(difflib.unified_diff(reference, real))
+
+        yield reference_file, diff[3:]

--- a/scale_build/utils/reference_files.py
+++ b/scale_build/utils/reference_files.py
@@ -1,6 +1,8 @@
 import os
 import difflib
 
+from scale_build.exceptions import CallError
+
 from .paths import REFERENCE_FILES_DIR, REFERENCE_FILES, CHROOT_BASEDIR
 
 
@@ -8,6 +10,9 @@ def compare_reference_files(cut_nonexistent_user_group_membership=False):
     for reference_file in REFERENCE_FILES:
         with open(os.path.join(REFERENCE_FILES_DIR, reference_file)) as f:
             reference = f.readlines()
+
+        if not os.path.exists(os.path.join(CHROOT_BASEDIR, reference_file)):
+            raise CallError(f'File {reference_file!r} does not exist in cached chroot')
 
         if cut_nonexistent_user_group_membership:
             if reference_file == 'etc/group':

--- a/scale_build/validate.py
+++ b/scale_build/validate.py
@@ -3,9 +3,11 @@ import jsonschema
 import logging
 import shutil
 
+from truenas_install import fhs
+
 from .exceptions import CallError, MissingPackagesException
 from .utils.manifest import validate_manifest
-from truenas_install import fhs
+from .utils.paths import REFERENCE_FILES, REFERENCE_FILES_DIR
 
 
 logger = logging.getLogger(__name__)
@@ -31,6 +33,11 @@ def validate_system_state():
     missing_packages = retrieve_missing_packages()
     if missing_packages:
         raise MissingPackagesException(missing_packages)
+
+    if missing_files := [
+        f for f in map(lambda f: os.path.join(REFERENCE_FILES_DIR, f), REFERENCE_FILES) if not os.path.exists(f)
+    ]:
+        raise CallError(f'Missing reference files: {", ".join(missing_files)!r}')
 
 
 def validate_datasets():


### PR DESCRIPTION
In the SCALE build process, when building the cache, it considers necessary cache files. If these files already exist, the SCALE build doesn't rebuild the cache, assuming the previous cache is sufficient. However, if the user or group information in the reference file has changed, the cache is declared as healthy, and the SCALE build doesn't rebuild the cache.

This PR effectively tackles that problems and ensures the cached bootstrapdir actually reflects the reference group/passwd files and if reference files have been changed, it invalidates the cache and initiates a clean build. Earlier what would happen is that during update phase usually the image won't build as we validate at that point if the users currently existing in the chroot env actually reference the reference group/passwd files.