### PR TITLE
NAS-125996 / 23.10.1.1 / add 23.10.1.1 build for middleware repo

### DIFF
--- a/conf/build.manifest
+++ b/conf/build.manifest
@@ -560,7 +560,7 @@ sources:
   branch: release/23.10.1
 - name: truenas
   repo: https://github.com/truenas/middleware
-  branch: release/23.10.1
+  branch: release/23.10.1.1
   subdir: debian
   subpackages:
     - name: middlewared


### PR DESCRIPTION
This will be used to create 23.10.1.1 hotfix release. All fixes are contained to `truenas/middleware` repo.