### PR TITLE
bump openssl to fix build

### DIFF
--- a/conf/build.manifest
+++ b/conf/build.manifest
@@ -316,7 +316,7 @@ iso-packages:
 sources:
 - name: openssl
   repo: https://github.com/truenas/openssl
-  branch: release/23.10.1
+  branch: release/23.10.1.1
   generate_version: false
   predepscmd:
     - "apt install -y wget xz-utils"


### PR DESCRIPTION
This pulls from 23.10.1.1 branch for our openssl branch to include a CVE fix as well as fix the package build.