### PR TITLE
Add truenas/webui 23.10.1.1 release branch to 23.10.1.1 build

### DIFF
--- a/conf/build.manifest
+++ b/conf/build.manifest
@@ -504,7 +504,7 @@ sources:
     - "yarn install"
     - "tar cvzf node_files.tgz node_modules/"
     - "rm -rf node_modules"
-  branch: release/23.10.1
+  branch: release/23.10.1.1
 - name: sedutil
   repo: https://github.com/truenas/sedutil
   branch: release/23.10.1


### PR DESCRIPTION
This is to bring in two bugfix commits related to network speed reporting into the build for quick validation ahead of the 23.10.1.1 release:

![image](https://github.com/truenas/scale-build/assets/17933320/96ba54e1-6585-4d72-a2a5-079523ab2ad7)
