### PR TITLE
NAS-125785 / 24.04 / Pull ssh packages from security mirror

### DIFF
--- a/conf/build.manifest
+++ b/conf/build.manifest
@@ -216,6 +216,9 @@ apt_preferences:
 - Package: "*polkit*"
   Pin: "release n=bookworm-security"
   Pin-Priority: 1000
+- Package: "*ssh*"
+  Pin: "release n=bookworm-security"
+  Pin-Priority: 1000
 - Package: "*ssl*"
   Pin: "release n=bookworm-security"
   Pin-Priority: 1000


### PR DESCRIPTION
This commit fixes a CVE affecting SSH packages