### PR TITLE
NAS-126694 / 24.04 / Switch scst branch from truenas-pre-3.8.x to truenas-3.8.x

### DIFF
--- a/conf/build.manifest
+++ b/conf/build.manifest
@@ -479,7 +479,7 @@ sources:
   explicit_deps:
     - kernel
     - kernel-dbg
-  branch: truenas-pre-3.8.x
+  branch: truenas-3.8.x
   subpackages:
     - name: scst-dbg
       generate_version: false


### PR DESCRIPTION
SCST 3.8 was [released](https://github.com/SCST-project/scst/releases/tag/v3.8) yesterday.

We want to switch to it in 24.04 and later in order to pickup the fix for NAS-126694 which was pushed upstream first (plus other fixes from upstream).

(We will cherry-pick the change into SCST `stable/cobia` branch.)