### PR TITLE
NAS-127113 / 24.04-BETA.1 / Explicitly add systemd-container to additional-packages list

### DIFF
--- a/conf/build.manifest
+++ b/conf/build.manifest
@@ -291,6 +291,9 @@ additional-packages:
 - name: i2c-tools
   comment: requested by platform team (NAS-120155)
   install_recommends: true
+- name: systemd-container
+  comment: requested by community (NAS-123533)
+  install_recommends: false
 
 #
 # List of additional packages installed into TrueNAS SCALE ISO file


### PR DESCRIPTION
As planned in https://ixsystems.atlassian.net/browse/NAS-125733. Ticket is already closed even though systemd-container is not added explicitly as a package to install. It's currently only included in SCALE as [a transient dependency of libvirt-daemon-system](https://github.com/truenas/middleware/blob/release/24.04-BETA.1/debian/debian/control). See my previous attempt at this PR for more info: https://github.com/truenas/scale-build/pull/482.