### PR TITLE
NAS-127122 / 24.10 / Preserve nvram files of vms across scale upgrades

### DIFF
--- a/truenas_install/__main__.py
+++ b/truenas_install/__main__.py
@@ -504,6 +504,8 @@ def main():
                             "etc/machine-id",
                             "home"
                         ])
+                        if os.path.exists('/var/lib/libvirt/qemu/nvram'):
+                            rsync.append('var/lib/libvirt/qemu/nvram')
 
                     run_command([
                         "rsync", "-aRx",


### PR DESCRIPTION
## Context

We want to preserve the nvram files created by VMs so in electric eel we can migrate them over to user based pools.
Some guests don't like it if they are not preserved and they lose their UEFI boot configuration.

Solution agreed upon was based on 2 parts:
1. Saving this file on user pools which is going to happen in electric eel
2. Until electric eel - for cobia/dragonfish we preserve these files across upgrades