### PR TITLE
NAS-127122 / 23.10.2 / Preserve nvram files of vms across scale upgrades (by Qubad786)

### DIFF
--- a/truenas_install/__main__.py
+++ b/truenas_install/__main__.py
@@ -463,6 +463,8 @@ def main():
                             "etc/machine-id",
                             "home"
                         ])
+                        if os.path.exists('/var/lib/libvirt/qemu/nvram'):
+                            rsync.append('var/lib/libvirt/qemu/nvram')
 
                         try:
                             logs = os.listdir(f"{old_root}/var/log")

--- a/truenas_install/__main__.py
+++ b/truenas_install/__main__.py
@@ -463,7 +463,7 @@ def main():
                             "etc/machine-id",
                             "home"
                         ])
-                        if os.path.exists('/var/lib/libvirt/qemu/nvram'):
+                        if os.path.exists(f'{old_root}/var/lib/libvirt/qemu/nvram'):
                             rsync.append('var/lib/libvirt/qemu/nvram')
 
                         try:


### PR DESCRIPTION
## Context

We want to preserve the nvram files created by VMs so in electric eel we can migrate them over to user based pools.
Some guests don't like it if they are not preserved and they lose their UEFI boot configuration.

Solution agreed upon was based on 2 parts:
1. Saving this file on user pools which is going to happen in electric eel
2. Until electric eel - for cobia/dragonfish we preserve these files across upgrades

Original PR: https://github.com/truenas/scale-build/pull/576
Jira URL: https://ixsystems.atlassian.net/browse/NAS-127122