### PR TITLE
NAS-127121 / 24.10 / Address CVE-2023-6246

### DIFF
--- a/conf/build.manifest
+++ b/conf/build.manifest
@@ -195,10 +195,10 @@ apt_preferences:
 - Package: "*cuda*"
   Pin: "version 525.89*"
   Pin-Priority: 1000
-- Package: "*libc6*"
+- Package: "*libc-*"
   Pin: "release n=bookworm-security"
   Pin-Priority: 1000
-- Package: "*libc-*"
+- Package: "*libc6*"
   Pin: "release n=bookworm-security"
   Pin-Priority: 1000
 - Package: "*libcrypto*"

--- a/conf/build.manifest
+++ b/conf/build.manifest
@@ -195,7 +195,7 @@ apt_preferences:
 - Package: "*cuda*"
   Pin: "version 525.89*"
   Pin-Priority: 1000
-- Package: "*libc6*"
+- Package: "*libc*"
   Pin: "release n=bookworm-security"
   Pin-Priority: 1000
 - Package: "*libcrypto*"

--- a/conf/build.manifest
+++ b/conf/build.manifest
@@ -195,7 +195,10 @@ apt_preferences:
 - Package: "*cuda*"
   Pin: "version 525.89*"
   Pin-Priority: 1000
-- Package: "*libc*"
+- Package: "*libc6*"
+  Pin: "release n=bookworm-security"
+  Pin-Priority: 1000
+- Package: "*libc-*"
   Pin: "release n=bookworm-security"
   Pin-Priority: 1000
 - Package: "*libcrypto*"

--- a/conf/build.manifest
+++ b/conf/build.manifest
@@ -195,6 +195,9 @@ apt_preferences:
 - Package: "*cuda*"
   Pin: "version 525.89*"
   Pin-Priority: 1000
+- Package: "*libc6*"
+  Pin: "release n=bookworm-security"
+  Pin-Priority: 1000
 - Package: "*libcrypto*"
   Pin: "origin \"\""
   Pin-Priority: 1050


### PR DESCRIPTION
This commit fixes a CVE found in glibc/libc6 by pulling it in from debian security mirror.