### PR TITLE
NAS-124714 / 24.10 / add py-cryptit to build

### DIFF
--- a/conf/build.manifest
+++ b/conf/build.manifest
@@ -560,6 +560,9 @@ sources:
 - name: k3s
   repo: https://github.com/truenas/k3s
   branch: truenas/master
+- name: py_cryptit
+  repo: https://github.com/truenas/py-cryptit
+  branch: master
 - name: py_sgio
   repo: https://github.com/truenas/py-sgio
   branch: master


### PR DESCRIPTION
Python is removing builtin `crypt` module in 3.13. To get ahead of the game, I wrote our own C bindings as a drop-in replacement.