### PR TITLE
Create netdata log directory on update/fresh installation

### DIFF
--- a/truenas_install/__main__.py
+++ b/truenas_install/__main__.py
@@ -589,6 +589,10 @@ def main():
 
                     setup_machine_id = configure_serial = True
 
+                # Making log dir for netdata
+                os.makedirs(os.path.join(root, "var/log/netdata"), exist_ok=True)
+                os.chown(os.path.join(root, "var/log/netdata"), 999, 997)
+
                 is_freebsd_loader_upgrade = is_freebsd_upgrade
                 if not is_freebsd_loader_upgrade and old_root is None and old_bootfs_prop != "-":
                     # Probably installing SCALE on CORE-formatted pool


### PR DESCRIPTION
## Problem
The Netdata log directory is currently created by the `netdata_setup` function in the middleware. However, the issue is that it runs on every netdata restart, whereas it should only be created once.

## Solution
The Netdata log directory will be created only once during the setup of the new BE (this applied to both fresh installation and update case)
