### PR TITLE
NAS-127301 / 24.04-RC.1 / add codename to manifest.json (by yocalebo)

### DIFF
--- a/scale_build/packages/build.py
+++ b/scale_build/packages/build.py
@@ -7,7 +7,7 @@ from datetime import datetime
 from scale_build.config import BUILD_TIME, VERSION
 from scale_build.exceptions import CallError
 from scale_build.utils.environment import APT_ENV
-from scale_build.utils.manifest import get_truenas_train
+from scale_build.utils.manifest import get_truenas_train, get_release_code_name
 from scale_build.utils.run import run
 from scale_build.utils.paths import PKG_DIR
 
@@ -79,6 +79,7 @@ class BuildPackageMixin:
                 f.write(json.dumps({
                     'buildtime': BUILD_TIME,
                     'train': get_truenas_train(),
+                    'codename': get_release_code_name(),
                     'version': VERSION,
                 }))
             os.makedirs(os.path.join(self.package_source_with_chroot, 'etc'), exist_ok=True)


### PR DESCRIPTION
Product management has asked us to add the code name on the UI side which needs to come from middleware which needs to come from this change 😄 

We already have this mostly automated but this will allow us to parse this value on middleware side.

Original PR: https://github.com/truenas/scale-build/pull/595
Jira URL: https://ixsystems.atlassian.net/browse/NAS-127301