### PR TITLE
NAS-127740 / 24.10 / Pin bookworm-security for node-related packages

### DIFF
--- a/conf/build.manifest
+++ b/conf/build.manifest
@@ -210,6 +210,9 @@ apt_preferences:
 - Package: "*libssl*"
   Pin: "origin \"\""
   Pin-Priority: 1050
+- Package: "*node*"
+  Pin: "release n=bookworm-security"
+  Pin-Priority: 1000
 - Package: "*nvidia*"
   Pin: "version 525.89*"
   Pin-Priority: 1000


### PR DESCRIPTION
This is required to unbreak the build.