### PR TITLE
NAS-128069 / 24.10 / Update python-netsnmpagent library

### DIFF
--- a/conf/build.manifest
+++ b/conf/build.manifest
@@ -530,7 +530,7 @@ sources:
   branch: master
 - name: python_netsnmpagent
   repo: https://github.com/truenas/python-netsnmpagent
-  branch: master
+  branch: truenas/0.6.1
 - name: python_truenas_requirements
   repo: https://github.com/truenas/python-truenas-requirements
   branch: master


### PR DESCRIPTION
This syncs up version of python-netsnmpagent with what is used in TrueNAS core, which includes many fixes (including use-after-free).