### PR TITLE
NAS-128110 / 24.10 / Add increased network timeout for yarn install.

### DIFF
--- a/conf/build.manifest
+++ b/conf/build.manifest
@@ -521,7 +521,7 @@ sources:
 - name: truenas_webui
   repo: https://github.com/truenas/webui
   prebuildcmd:
-    - "yarn install"
+    - "yarn install --network-timeout 100000"
     - "tar cvzf node_files.tgz node_modules/"
     - "rm -rf node_modules"
   branch: master


### PR DESCRIPTION
This works around an intermittent issue seen on lower-resourced build VMs.

---
Issue has been seen on:
- On XEN VM
- On Hyper-V VM

Did a successful build with the change [here](https://ci.tn.ixsystems.net/jenkins/job/TrueNAS%20SCALE%20-%20Unstable/job/Build%20-%20TrueNAS%20SCALE_Custom/799/)