### PR TITLE
NAS-127880 / 24.10 / Make sure we copy over netdata state from previous BE to new BE

### DIFF
--- a/truenas_install/__main__.py
+++ b/truenas_install/__main__.py
@@ -452,6 +452,8 @@ def main():
                         rsync.append("home")
                     if os.path.exists(f"{old_root}/var/lib/libvirt/qemu/nvram"):
                         rsync.append("var/lib/libvirt/qemu/nvram")
+                    if os.path.exists(f"{old_root}/var/lib/netdata"):
+                        rsync.append("var/lib/netdata")
                     if "var/log" not in cloned_datasets:
                         try:
                             logs = os.listdir(f"{old_root}/var/log")


### PR DESCRIPTION
## Context

We want to copy over netdata state from older BE to new BE - this basically just contains a few KB of data which includes a UUID which netdata uses to identify itself which we want to essentially persist across upgrades.