### PR TITLE
NAS-127880 / 24.04.0 / Make sure we copy over netdata state from previous BE to new BE (by Qubad786)

### DIFF
--- a/truenas_install/__main__.py
+++ b/truenas_install/__main__.py
@@ -558,6 +558,8 @@ def main():
                             rsync.append("home")
                         if os.path.exists(f"{old_root}/var/lib/libvirt/qemu/nvram"):
                             rsync.append("var/lib/libvirt/qemu/nvram")
+                        if os.path.exists(f"{old_root}/var/lib/netdata"):
+                            rsync.append("var/lib/netdata")
                         if "var/log" not in cloned_datasets:
                             try:
                                 logs = os.listdir(f"{old_root}/var/log")


### PR DESCRIPTION
Automatic cherry-pick failed. Please resolve conflicts by running:

    git reset --hard HEAD~1
    git cherry-pick -x f57ba5224d255ae57ab4b0e5992b6a52766174af

If the original PR was merged via a squash, you can just cherry-pick the squashed commit:

    git reset --hard HEAD~1
    git cherry-pick -x e7ce75c036df7fc0bd53c8072fef0a3df8623dd9

## Context

We want to copy over netdata state from older BE to new BE - this basically just contains a few KB of data which includes a UUID which netdata uses to identify itself which we want to essentially persist across upgrades.

Original PR: https://github.com/truenas/scale-build/pull/609
Jira URL: https://ixsystems.atlassian.net/browse/NAS-127880