### PR TITLE
NAS-128497 / 24.10 / remove unmaintained chelsiouwire

### DIFF
--- a/conf/build.manifest
+++ b/conf/build.manifest
@@ -338,9 +338,6 @@ sources:
   predepscmd:
     - "apt install -y wget xz-utils"
     - "./pull.sh"
-- name: chelsio_uwire
-  repo: https://github.com/truenas/chelsiouwire
-  branch: master
 - name: openseachest
   branch: master
   repo: https://github.com/truenas/openseachest

--- a/conf/build.manifest
+++ b/conf/build.manifest
@@ -264,9 +264,6 @@ additional-packages:
 - name: openseachest
   comment: requested by performance team (NAS-106154)
   install_recommends: true
-- name: cxgbtool
-  comment: requested by OS team (NAS-111041)
-  install_recommends: true
 - name: python-is-python3
   comment: NAS-111358 (symlinks /usr/bin/python to python3)
   install_recommends: true


### PR DESCRIPTION
This is unmaintained and I've confirmed that it's shipping a broken `chelsio_adapter_config.py` script which is, essentially, the entire purpose of this repo. This has been broken since SCALE has been released publicly which is why I can justify removing it from the build. I will work with platform team on a proper solution.

NOTE: the only tool we install from this repo is `cxgbtool`. Again, we don't have that on CORE and we're not using it on SCALE. This repo is too large with too much cruft to justify shipping SCALE with a tool that's not even used and shipping a script that doesn't even work.

P.S. linux has proper in-tree drivers for all the various Chelsio cards so we're losing no functionality (with the exception of `cxgbtool` (that we don't even use))

P.S.S. Making a correction. We do, in fact, have cxgbetool on CORE but it's not immediately obvious if we actually use it. Again, the entire point of this repo is to have the ability to flash certain cards to operate a different way. We don't need the cxgbtool (AFAICS) to do this.