### PR TITLE
NAS-128548 / 24.10 / bump epoch since apt cdn urls changed

### DIFF
--- a/conf/build.manifest
+++ b/conf/build.manifest
@@ -181,7 +181,7 @@ base-prune:
 # Update build-epoch when you want to force the next build to be
 # non-incremental
 ############################################################################
-build-epoch: 10
+build-epoch: 11
 
 # Apt Preferences
 ############################################################################


### PR DESCRIPTION
Looks like we need to bump epoch since the APT urls changed. Incremental jobs fail to build since the cached packages still reference the old APT urls. This seems like the only fool-proof way to clean it up.