### PR TITLE
NAS-128574 / 24.10 / Switch scst branch from truenas-3.8.x to truenas-3.9.0-pre

### DIFF
--- a/conf/build.manifest
+++ b/conf/build.manifest
@@ -498,7 +498,7 @@ sources:
   explicit_deps:
     - kernel
     - kernel-dbg
-  branch: truenas-3.8.x
+  branch: truenas-3.9.0-pre
   subpackages:
     - name: scst-dbg
       generate_version: false


### PR DESCRIPTION
Rolling to SCST tip to pickup a couple of changes we pushed upstream:
- iscsi-scst: Add mechanism to restore target parameter to default (#[232](https://github.com/SCST-project/scst/pull/232))
- iscsi-scst: Add `link_local` parameter (#[228](https://github.com/SCST-project/scst/pull/228))