### PR TITLE
NAS-128746 / 24.10 / Add basic avahi configuration to ISO installer

### DIFF
--- a/conf/cd-files/etc/avahi/avahi-daemon.conf
+++ b/conf/cd-files/etc/avahi/avahi-daemon.conf
@@ -1,0 +1,7 @@
+[server]
+ratelimit-interval-usec=1000000
+ratelimit-burst=1000
+deny-interfaces=lo
+
+[wide-area]
+enable-wide-area=yes

--- a/conf/cd-files/etc/avahi/services/HTTP.service
+++ b/conf/cd-files/etc/avahi/services/HTTP.service
@@ -1,0 +1,7 @@
+<service-group>
+  <name replace-wildcards="yes">%h</name>
+  <service>
+    <type>_http._tcp.</type>
+    <port>80</port>
+  </service>
+</service-group>

--- a/conf/cd-files/etc/avahi/services/TRUENAS_INSTALLER.service
+++ b/conf/cd-files/etc/avahi/services/TRUENAS_INSTALLER.service
@@ -1,0 +1,8 @@
+<service-group>
+  <name replace-wildcards="yes">%h</name>
+  <service>
+    <type>_truenas_installer._tcp.</type>
+    <port>80</port>
+    <txt-record>status=INIT,version=UNKNOWN</txt-record>
+  </service>
+</service-group>

--- a/scale_build/image/iso.py
+++ b/scale_build/image/iso.py
@@ -52,7 +52,7 @@ def make_iso_file():
 
     # Set /etc/hostname so that hostname of builder is not advertised
     with open(os.path.join(CHROOT_BASEDIR, 'etc/hostname'), 'w') as f:
-        f.write('truenas.local')
+        f.write('truenas-installer.local')
 
     # Copy the CD files
     run(f'rsync -aKv {CD_FILES_DIR}/ {CHROOT_BASEDIR}/', shell=True)


### PR DESCRIPTION
This some basic avahi configuration to the installer so that the avahi-daemon can start properly on boot and indicate the installer service is in an INIT state.