### PR TITLE
NAS-128714 / 24.10 / Make changes to correct perms on /data

### DIFF
--- a/truenas_install/__main__.py
+++ b/truenas_install/__main__.py
@@ -477,9 +477,13 @@ def main():
 
                     setup_machine_id = configure_serial = True
 
-                # We do not want /data directory to be world readable
+                # We only want /data itself (without contents) and /data/subsystems to be 755
+                # whereas everything else should be 700
                 # Doing this here is important so that we cover both fresh install and upgrade case
                 run_command(["chmod", "-R", "u=rwX,g=,o=", f"{root}/data"])
+                run_command(["chmod", "u=rwx,g=rx,o=rx", os.path.join(root, "data")])
+                if os.path.exists(os.path.join(root, "data/subsystems")):
+                    run_command(["chmod", "-R", "u=rwx,g=rx,o=rx", os.path.join(root, "data/subsystems")])
 
                 if setup_machine_id:
                     with contextlib.suppress(FileNotFoundError):

--- a/truenas_install/fhs.py
+++ b/truenas_install/fhs.py
@@ -103,7 +103,7 @@ TRUENAS_DATASETS = [
     {
         'name':  'data',
         'options': ['NOSUID', 'NOEXEC', 'NOACL', 'NOATIME'],
-        'mode': 0o700,
+        'mode': 0o755,
         'clone': True,
     },
     {


### PR DESCRIPTION
## Problem

Different subsystems in `/data/subsystems` expects that their relevant users are able to read/write data in their respective dirs i.e libvirt. However with recursively doing `700` on `/data` that is not possible which results in those subsystems breaking.

## Solution

After discussing with Andrew, the best possible way forward which has been deduced is to do the following:
1. `700` on `/data` recursively ensuring everything inside has `700` perms
2. `755` on just `/data` itself
3. `755` recursively on `/data/subsystems`

This approach ensures that most of the stuff which is sensitive has correct perms in place preventing misuse and necessary directories which can/should be accessed are accessible by their respective users. 