### PR TITLE
NAS-129054 / 24.10 / Enforce data directory paths and permissions

### DIFF
--- a/scale_build/validate.py
+++ b/scale_build/validate.py
@@ -3,7 +3,7 @@ import jsonschema
 import logging
 import shutil
 
-from truenas_install import fhs
+from truenas_install import dhs, fhs
 
 from .exceptions import CallError, MissingPackagesException
 from .utils.manifest import validate_manifest
@@ -47,7 +47,14 @@ def validate_datasets():
         raise CallError(f'Provided dataset schema is invalid: {e}')
 
 
-def validate(system_state_flag=True, manifest_flag=True, datasets_flag=True):
+def validate_data_dir_schema():
+    try:
+        jsonschema.validate(dhs.TRUENAS_DATA_HIERARCHY, dhs.TRUENAS_DATA_HIERARCHY_SCHEMA)
+    except jsonschema.ValidationError as e:
+        raise CallError(f'Provided data hierarchy schema is invalid: {e}')
+
+
+def validate(system_state_flag=True, manifest_flag=True, datasets_flag=True, data_flag=True):
     if system_state_flag:
         validate_system_state()
         logger.debug('System state Validated')
@@ -58,3 +65,7 @@ def validate(system_state_flag=True, manifest_flag=True, datasets_flag=True):
     if datasets_flag:
         validate_datasets()
         logger.debug('Dataset schema Validated')
+
+    if data_flag:
+        validate_data_dir_schema()
+        logger.debug('Data directory schema Validated')

--- a/truenas_install/dhs.py
+++ b/truenas_install/dhs.py
@@ -1,0 +1,67 @@
+TRUENAS_DATA_HIERARCHY_SCHEMA = {
+    '$schema': 'http://json-schema.org/draft-07/schema#',
+    'type': 'array',
+    'items': {
+        'type': 'object',
+        'properties': {
+            'path': {'type': 'string', 'pattern': r'^data.*'},
+            'mode': {
+                'type': 'object',
+                'properties': {
+                    'user': {'type': 'string', 'pattern': r'^(r?w?[xX]?)?$'},
+                    'group': {'type': 'string', 'pattern': r'^(r?w?[xX]?)?$'},
+                    'other': {'type': 'string', 'pattern': r'^(r?w?[xX]?)?$'},
+                },
+                'required': ['user', 'group', 'other'],
+                'additionalProperties': False,
+            },
+            'recursive': {'type': 'boolean'},
+        },
+        'required': ['path'],
+        'additionalProperties': False,
+        'dependencies': {
+            'recursive': ['mode'],
+            'mode': ['recursive']
+        },
+    }
+}
+
+
+TRUENAS_DATA_HIERARCHY = [
+    {
+        'path': 'data',
+        'mode': {
+            'user': 'rwx',
+            'group': 'rx',
+            'other': 'rx',
+        },
+        'recursive': False,
+    },
+    {
+        'path':  'data/subsystems',
+        'mode': {
+            'user': 'rwx',
+            'group': 'rx',
+            'other': 'rx',
+        },
+        'recursive': True,
+    },
+    {
+        'path': 'data/subsystems/vm',
+    },
+    {
+        'path': 'data/subsystems/vm/nvram',
+    },
+    {
+        'path': 'data/zfs',
+        'mode': {
+            'user': 'rwx',
+            'group': '',
+            'other': '',
+        },
+        'recursive': True,
+    },
+    {
+        'path': 'data/sentinels',
+    }
+]


### PR DESCRIPTION
## Problem

Certain essential files and directories, such as subsystems and ZFS, are stored in the `/data` directory. Each of these files and directories must have their own specific permissions, and some of them must exist for the OS to function properly.

## Improvement

Define a data hierarchy to ensure that the `/data` directory follows the specified structure. If the specified hierarchy does not exist, create the necessary directories and set the relevant permissions.
