### PR TITLE
NAS-129248 / 24.10 / Use pre-built nodejs for truenas_webui

### DIFF
--- a/conf/build.manifest
+++ b/conf/build.manifest
@@ -524,7 +524,10 @@ sources:
   branch: master
 - name: truenas_webui
   repo: https://github.com/truenas/webui
+  predepscmd:
+    - "apt -y install wget && apt -y install yarn --no-install-recommends"  # yarn recommends nodejs, which we don't want
   prebuildcmd:
+    - "sh -ex debian/fetch_node.sh"  # download and install pre-built nodejs
     - "yarn install --network-timeout 100000"
     - "tar cvzf node_files.tgz node_modules/"
     - "rm -rf node_modules"


### PR DESCRIPTION
This commit changes the truenas_webui build process so that we download the version specified in the fetch script from upstream, validate the shasum for tarball, and install in the chroot environment for the truenas_webui package build.

This ensures that the webui team can specify which nodejs version to build against without having to rely on upstream debian package.