### PR TITLE
Add cifs-utils to base packages

### DIFF
--- a/conf/build.manifest
+++ b/conf/build.manifest
@@ -118,6 +118,8 @@ base-packages:
   install_recommends: true
 - name: truenas-sssd
   install_recommends: true
+- name: cifs-utils
+  install_recommends: true
 - name: nfs4xdr-acl-tools
   install_recommends: true
 - name: nfs4-acl-tools


### PR DESCRIPTION
This was originally hosted in truenas-files. Moving to base packages after truenas-samba simplifies dependency resolution since cifs-utils depends on libwbclient and libtalloc.