### PR TITLE
NAS-129353 / 24.10 / Correctly reference entry key

### DIFF
--- a/truenas_install/__main__.py
+++ b/truenas_install/__main__.py
@@ -485,7 +485,7 @@ def main():
                 # Doing this here is important so that we cover both fresh install and upgrade case
                 run_command(["chmod", "-R", "u=rwX,g=,o=", f"{root}/data"])
                 for entry in TRUENAS_DATA_HIERARCHY:
-                    entry_path = os.path.join(root, entry["dir_path"])
+                    entry_path = os.path.join(root, entry["path"])
                     os.makedirs(entry_path, exist_ok=True)
                     if mode := entry.get("mode"):
                         mode = f"u={mode['user']},g={mode['group']},o={mode['other']}"


### PR DESCRIPTION
## Context

We were incorrectly referencing path key for each entry defined in data hierarchy which led to `truenas_install` execution failing.