### PR TITLE
NAS-129655 / 24.04.2 / bump _VERS in stable/dragonfish

### DIFF
--- a/scale_build/config.py
+++ b/scale_build/config.py
@@ -3,7 +3,7 @@ from time import time
 from datetime import datetime
 
 IDENTITY_FILE_PATH_OVERRIDE_SUFFIX = '_OVERRIDE_IDENTITY_FILE_PATH'
-_VERS = '24.04.2-MASTER'
+_VERS = '24.04.3-MASTER'
 
 
 def get_env_variable(key, _type, default_value=None):


### PR DESCRIPTION
Bump this to 24.04.3-MASTER so anyone running 24.04.2 can upgrade to the "next" release (even though, at the time of writing this, we have no plans for a 24.04.3 release).