### PR TITLE
NAS-129797 - adding vendor to build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,6 @@ REPO_CHANGED=$(shell if [ -d "./venv-$(COMMIT_HASH)" ]; then git status --porcel
 BREAK_SYS_PKGS_FLAG=$(shell ${PYTHON} -m pip help install | grep -q -- '--break-system-packages' && echo "--break-system-packages" || echo "")
 
 .DEFAULT_GOAL := all
-VENDOR?=truenas
 
 check:
 ifneq ($(REPO_CHANGED),0)

--- a/Makefile
+++ b/Makefile
@@ -9,6 +9,7 @@ REPO_CHANGED=$(shell if [ -d "./venv-$(COMMIT_HASH)" ]; then git status --porcel
 BREAK_SYS_PKGS_FLAG=$(shell ${PYTHON} -m pip help install | grep -q -- '--break-system-packages' && echo "--break-system-packages" || echo "")
 
 .DEFAULT_GOAL := all
+VENDOR?=truenas
 
 check:
 ifneq ($(REPO_CHANGED),0)

--- a/scale_build/config.py
+++ b/scale_build/config.py
@@ -47,6 +47,7 @@ TRAIN = get_env_variable('TRUENAS_TRAIN', str)
 TRUENAS_BRANCH_OVERRIDE = get_env_variable('TRUENAS_BRANCH_OVERRIDE', str)
 TRY_BRANCH_OVERRIDE = get_env_variable('TRY_BRANCH_OVERRIDE', str)
 VERSION = get_env_variable('TRUENAS_VERSION', str, f'{_VERS}-{BUILD_TIME_OBJ.strftime("%Y%m%d-%H%M%S")}')
+TRUENAS_VENDOR = get_env_variable('TRUENAS_VENDOR', str)
 
 
 # We will get branch overrides and identity file path overrides from here

--- a/scale_build/image/iso.py
+++ b/scale_build/image/iso.py
@@ -13,7 +13,9 @@ from scale_build.exceptions import CallError
 from scale_build.utils.manifest import get_manifest
 from scale_build.utils.run import run
 from scale_build.utils.paths import CD_DIR, CD_FILES_DIR, CHROOT_BASEDIR, CONF_GRUB, PKG_DIR, RELEASE_DIR, TMP_DIR
-
+from scale_build.config import (
+    TRUENAS_VENDOR
+)
 from .bootstrap import umount_chroot_basedir
 from .manifest import get_image_version, update_file_path
 from .utils import run_in_chroot
@@ -55,11 +57,10 @@ def make_iso_file():
     with open(os.path.join(CHROOT_BASEDIR, 'etc/hostname'), 'w') as f:
         f.write('truenas-installer.local')
 
-    vendor = os.environ.get('TRUENAS_VENDOR')
-    if vendor:
+    if TRUENAS_VENDOR:
         os.makedirs(os.path.join(CHROOT_BASEDIR, 'data'), exist_ok=True)
         with open(os.path.join(CHROOT_BASEDIR, 'data/.vendor'), 'w') as f:
-            f.write(json.dumps({'name': vendor}))
+            f.write(json.dumps({'name': TRUENAS_VENDOR}))
 
     # Copy the CD files
     run(f'rsync -aKv {CD_FILES_DIR}/ {CHROOT_BASEDIR}/', shell=True)

--- a/scale_build/image/iso.py
+++ b/scale_build/image/iso.py
@@ -119,7 +119,7 @@ def make_iso_file():
         shutil.copy(os.path.join(CHROOT_BASEDIR, 'usr/share/grub/unicode.pf2'),
                     os.path.join(CD_DIR, 'EFI/debian/fonts/unicode.pf2'))
 
-        iso = os.path.join(RELEASE_DIR, f'TrueNAS-SCALE-{get_image_version()}.iso')
+        iso = os.path.join(RELEASE_DIR, f'TrueNAS-SCALE-{get_image_version(vendor=TRUENAS_VENDOR)}.iso')
 
         # Default grub EFI image does not support `search` command which we need to make TrueNAS ISO working in
         # Rufus "ISO Image mode".
@@ -191,9 +191,9 @@ def make_iso_file():
         run(['umount', '-f', os.path.join(CHROOT_BASEDIR, RELEASE_DIR)])
         run(['umount', '-f', os.path.join(CHROOT_BASEDIR, 'packages')])
 
-    with open(os.path.join(RELEASE_DIR, f'TrueNAS-SCALE-{get_image_version()}.iso.sha256'), 'w') as f:
+    with open(os.path.join(RELEASE_DIR, f'TrueNAS-SCALE-{get_image_version(vendor=TRUENAS_VENDOR)}.iso.sha256'), 'w') as f:
         f.write(run(
-            ['sha256sum', os.path.join(RELEASE_DIR, f'TrueNAS-SCALE-{get_image_version()}.iso')], log=False
+            ['sha256sum', os.path.join(RELEASE_DIR, f'TrueNAS-SCALE-{get_image_version(vendor=TRUENAS_VENDOR)}.iso')], log=False
         ).stdout.replace(f'{RELEASE_DIR}/', '').strip())
 
 

--- a/scale_build/image/iso.py
+++ b/scale_build/image/iso.py
@@ -5,7 +5,6 @@ import shutil
 import tarfile
 import tempfile
 import time
-import json
 
 import requests
 
@@ -60,7 +59,7 @@ def make_iso_file():
     if TRUENAS_VENDOR:
         os.makedirs(os.path.join(CHROOT_BASEDIR, 'data'), exist_ok=True)
         with open(os.path.join(CHROOT_BASEDIR, 'data/.vendor'), 'w') as f:
-            f.write(json.dumps({'name': TRUENAS_VENDOR}))
+            f.write('{"name": "%s"}', TRUENAS_VENDOR)
 
     # Copy the CD files
     run(f'rsync -aKv {CD_FILES_DIR}/ {CHROOT_BASEDIR}/', shell=True)

--- a/scale_build/image/iso.py
+++ b/scale_build/image/iso.py
@@ -5,6 +5,7 @@ import shutil
 import tarfile
 import tempfile
 import time
+import json
 
 import requests
 
@@ -53,6 +54,12 @@ def make_iso_file():
     # Set /etc/hostname so that hostname of builder is not advertised
     with open(os.path.join(CHROOT_BASEDIR, 'etc/hostname'), 'w') as f:
         f.write('truenas-installer.local')
+
+    vendor = os.environ.get('VENDOR')
+    if vendor:
+        os.makedirs(os.path.join(CHROOT_BASEDIR, 'data'), exist_ok=True)
+        with open(os.path.join(CHROOT_BASEDIR, 'data/.vendor'), 'w') as f:
+            f.write(json.dumps({'name': vendor}))   
 
     # Copy the CD files
     run(f'rsync -aKv {CD_FILES_DIR}/ {CHROOT_BASEDIR}/', shell=True)

--- a/scale_build/image/iso.py
+++ b/scale_build/image/iso.py
@@ -57,7 +57,7 @@ def make_iso_file():
         f.write('truenas-installer.local')
 
     if TRUENAS_VENDOR:
-        os.makedirs(os.path.join(CHROOT_BASEDIR, 'data'), exist_ok=True)
+        os.makedirs(os.path.join(CHROOT_BASEDIR, 'data'))
         with open(os.path.join(CHROOT_BASEDIR, 'data/.vendor'), 'w') as f:
             f.write('{"name": "%s"}', TRUENAS_VENDOR)
 

--- a/scale_build/image/iso.py
+++ b/scale_build/image/iso.py
@@ -5,6 +5,7 @@ import shutil
 import tarfile
 import tempfile
 import time
+import json
 
 import requests
 
@@ -59,7 +60,7 @@ def make_iso_file():
     if TRUENAS_VENDOR:
         os.makedirs(os.path.join(CHROOT_BASEDIR, 'data'))
         with open(os.path.join(CHROOT_BASEDIR, 'data/.vendor'), 'w') as f:
-            f.write('{"name": "%s"}', TRUENAS_VENDOR)
+            f.write(json.dumps({'name': TRUENAS_VENDOR}))
 
     # Copy the CD files
     run(f'rsync -aKv {CD_FILES_DIR}/ {CHROOT_BASEDIR}/', shell=True)

--- a/scale_build/image/iso.py
+++ b/scale_build/image/iso.py
@@ -55,7 +55,7 @@ def make_iso_file():
     with open(os.path.join(CHROOT_BASEDIR, 'etc/hostname'), 'w') as f:
         f.write('truenas-installer.local')
 
-    vendor = os.environ.get('VENDOR')
+    vendor = os.environ.get('TRUENAS_VENDOR')
     if vendor:
         os.makedirs(os.path.join(CHROOT_BASEDIR, 'data'), exist_ok=True)
         with open(os.path.join(CHROOT_BASEDIR, 'data/.vendor'), 'w') as f:

--- a/scale_build/image/iso.py
+++ b/scale_build/image/iso.py
@@ -190,9 +190,10 @@ def make_iso_file():
         run(['umount', '-f', os.path.join(CHROOT_BASEDIR, RELEASE_DIR)])
         run(['umount', '-f', os.path.join(CHROOT_BASEDIR, 'packages')])
 
-    with open(os.path.join(RELEASE_DIR, f'TrueNAS-SCALE-{get_image_version(vendor=TRUENAS_VENDOR)}.iso.sha256'), 'w') as f:
+    image_version = get_image_version(vendor=TRUENAS_VENDOR)
+    with open(os.path.join(RELEASE_DIR, f'TrueNAS-SCALE-{image_version}.iso.sha256'), 'w') as f:
         f.write(run(
-            ['sha256sum', os.path.join(RELEASE_DIR, f'TrueNAS-SCALE-{get_image_version(vendor=TRUENAS_VENDOR)}.iso')], log=False
+            ['sha256sum', os.path.join(RELEASE_DIR, f'TrueNAS-SCALE-{image_version}.iso')], log=False
         ).stdout.replace(f'{RELEASE_DIR}/', '').strip())
 
 

--- a/scale_build/image/iso.py
+++ b/scale_build/image/iso.py
@@ -59,7 +59,7 @@ def make_iso_file():
     if vendor:
         os.makedirs(os.path.join(CHROOT_BASEDIR, 'data'), exist_ok=True)
         with open(os.path.join(CHROOT_BASEDIR, 'data/.vendor'), 'w') as f:
-            f.write(json.dumps({'name': vendor}))   
+            f.write(json.dumps({'name': vendor}))
 
     # Copy the CD files
     run(f'rsync -aKv {CD_FILES_DIR}/ {CHROOT_BASEDIR}/', shell=True)

--- a/scale_build/image/manifest.py
+++ b/scale_build/image/manifest.py
@@ -7,7 +7,9 @@ import subprocess
 
 from scale_build.exceptions import CallError
 from scale_build.utils.paths import BUILDER_DIR, CHROOT_BASEDIR, RELEASE_DIR, UPDATE_DIR
-
+from scale_build.config import (
+    TRUENAS_VENDOR
+)
 
 RELEASE_MANIFEST = os.path.join(RELEASE_DIR, 'manifest.json')
 
@@ -69,7 +71,7 @@ def get_image_version():
         raise CallError(f'{RELEASE_MANIFEST!r} does not exist')
 
     with open(RELEASE_MANIFEST) as f:
-        vendor = f"-{os.environ['TRUENAS_VENDOR']}" if os.environ.get('TRUENAS_VENDOR') else ""
+        vendor = f"-{TRUENAS_VENDOR}" if TRUENAS_VENDOR else ""
         return f"{json.load(f)['version']}{vendor}"
 
 

--- a/scale_build/image/manifest.py
+++ b/scale_build/image/manifest.py
@@ -69,7 +69,8 @@ def get_image_version():
         raise CallError(f'{RELEASE_MANIFEST!r} does not exist')
 
     with open(RELEASE_MANIFEST) as f:
-        return json.load(f)['version']
+        vendor = f"-{os.environ['VENDOR']}" if os.environ.get('VENDOR') else ""
+        return f"{json.load(f)['version']}{vendor}"
 
 
 def update_file_path(version=None):

--- a/scale_build/image/manifest.py
+++ b/scale_build/image/manifest.py
@@ -69,7 +69,7 @@ def get_image_version():
         raise CallError(f'{RELEASE_MANIFEST!r} does not exist')
 
     with open(RELEASE_MANIFEST) as f:
-        vendor = f"-{os.environ['VENDOR']}" if os.environ.get('VENDOR') else ""
+        vendor = f"-{os.environ['TRUENAS_VENDOR']}" if os.environ.get('TRUENAS_VENDOR') else ""
         return f"{json.load(f)['version']}{vendor}"
 
 

--- a/scale_build/image/manifest.py
+++ b/scale_build/image/manifest.py
@@ -7,9 +7,7 @@ import subprocess
 
 from scale_build.exceptions import CallError
 from scale_build.utils.paths import BUILDER_DIR, CHROOT_BASEDIR, RELEASE_DIR, UPDATE_DIR
-from scale_build.config import (
-    TRUENAS_VENDOR
-)
+
 
 RELEASE_MANIFEST = os.path.join(RELEASE_DIR, 'manifest.json')
 
@@ -67,7 +65,6 @@ def build_release_manifest(update_file, update_file_checksum):
 
 
 def get_image_version(vendor=None):
-    """If vendor is set, append it to the version."""
     if not os.path.exists(RELEASE_MANIFEST):
         raise CallError(f'{RELEASE_MANIFEST!r} does not exist')
 

--- a/scale_build/image/manifest.py
+++ b/scale_build/image/manifest.py
@@ -66,12 +66,13 @@ def build_release_manifest(update_file, update_file_checksum):
         }, f)
 
 
-def get_image_version():
+def get_image_version(vendor=None):
+    """If vendor is set, append it to the version."""
     if not os.path.exists(RELEASE_MANIFEST):
         raise CallError(f'{RELEASE_MANIFEST!r} does not exist')
 
     with open(RELEASE_MANIFEST) as f:
-        vendor = f"-{TRUENAS_VENDOR}" if TRUENAS_VENDOR else ""
+        vendor = f"-{vendor}" if vendor else ""
         return f"{json.load(f)['version']}{vendor}"
 
 

--- a/scale_build/iso.py
+++ b/scale_build/iso.py
@@ -26,7 +26,7 @@ def build_impl():
     for f in glob.glob(os.path.join(LOG_DIR, 'cdrom*')):
         os.unlink(f)
 
-    version = build_manifest() # Otherwise, it looks for a vendor in the filename. Update files never have a vendor.
+    version = build_manifest()  # Otherwise, it looks for a vendor in the filename. Update files never have a vendor.
     if not os.path.exists(update_file_path(version)):
         raise CallError(f'Missing rootfs image. Run \'make update\' first.{update_file_path()}')
 

--- a/scale_build/iso.py
+++ b/scale_build/iso.py
@@ -26,7 +26,7 @@ def build_impl():
     for f in glob.glob(os.path.join(LOG_DIR, 'cdrom*')):
         os.unlink(f)
 
-    version = build_manifest() # Otherwise, it looks for a vendor in the filename
+    version = build_manifest() # Otherwise, it looks for a vendor in the filename. Update files never have a vendor.
     if not os.path.exists(update_file_path(version)):
         raise CallError(f'Missing rootfs image. Run \'make update\' first.{update_file_path()}')
 

--- a/scale_build/iso.py
+++ b/scale_build/iso.py
@@ -30,7 +30,7 @@ def build_impl():
         os.unlink(f)
 
     if not os.path.exists(update_file_path()):
-        raise CallError(f'Missing rootfs image. Run \'make update\' first.{update_file_path()}')
+        raise CallError('Missing rootfs image. Run \'make update\' first.')
 
     logger.debug('Bootstrapping CD chroot [ISO] (%s/cdrom-bootstrap.log)', LOG_DIR)
     with LoggingContext('cdrom-bootstrap', 'w'):

--- a/scale_build/iso.py
+++ b/scale_build/iso.py
@@ -6,7 +6,7 @@ from .bootstrap.bootstrapdir import CdromBootstrapDirectory
 from .exceptions import CallError
 from .image.bootstrap import clean_mounts, setup_chroot_basedir, umount_tmpfs_and_clean_chroot_dir
 from .image.iso import install_iso_packages, make_iso_file
-from .image.manifest import get_image_version, update_file_path
+from .image.manifest import get_image_version, update_file_path, build_manifest
 from .utils.logger import LoggingContext
 from .utils.paths import LOG_DIR, RELEASE_DIR
 
@@ -26,8 +26,9 @@ def build_impl():
     for f in glob.glob(os.path.join(LOG_DIR, 'cdrom*')):
         os.unlink(f)
 
-    if not os.path.exists(update_file_path()):
-        raise CallError('Missing rootfs image. Run \'make update\' first.')
+    version = build_manifest() # Otherwise, it looks for a vendor in the filename
+    if not os.path.exists(update_file_path(version)):
+        raise CallError(f'Missing rootfs image. Run \'make update\' first.{update_file_path()}')
 
     logger.debug('Bootstrapping CD chroot [ISO] (%s/cdrom-bootstrap.log)', LOG_DIR)
     with LoggingContext('cdrom-bootstrap', 'w'):

--- a/scale_build/iso.py
+++ b/scale_build/iso.py
@@ -6,7 +6,7 @@ from .bootstrap.bootstrapdir import CdromBootstrapDirectory
 from .exceptions import CallError
 from .image.bootstrap import clean_mounts, setup_chroot_basedir, umount_tmpfs_and_clean_chroot_dir
 from .image.iso import install_iso_packages, make_iso_file
-from .image.manifest import get_image_version, update_file_path, build_manifest
+from .image.manifest import get_image_version, update_file_path
 from .utils.logger import LoggingContext
 from .utils.paths import LOG_DIR, RELEASE_DIR
 
@@ -26,8 +26,7 @@ def build_impl():
     for f in glob.glob(os.path.join(LOG_DIR, 'cdrom*')):
         os.unlink(f)
 
-    version = get_image_version()
-    if not os.path.exists(update_file_path(version)):
+    if not os.path.exists(update_file_path()):
         raise CallError(f'Missing rootfs image. Run \'make update\' first.{update_file_path()}')
 
     logger.debug('Bootstrapping CD chroot [ISO] (%s/cdrom-bootstrap.log)', LOG_DIR)

--- a/scale_build/iso.py
+++ b/scale_build/iso.py
@@ -26,7 +26,7 @@ def build_impl():
     for f in glob.glob(os.path.join(LOG_DIR, 'cdrom*')):
         os.unlink(f)
 
-    version = build_manifest()  # Otherwise, it looks for a vendor in the filename. Update files never have a vendor.
+    version = get_image_version()
     if not os.path.exists(update_file_path(version)):
         raise CallError(f'Missing rootfs image. Run \'make update\' first.{update_file_path()}')
 

--- a/scale_build/iso.py
+++ b/scale_build/iso.py
@@ -9,6 +9,9 @@ from .image.iso import install_iso_packages, make_iso_file
 from .image.manifest import get_image_version, update_file_path
 from .utils.logger import LoggingContext
 from .utils.paths import LOG_DIR, RELEASE_DIR
+from .config import (
+    TRUENAS_VENDOR
+)
 
 
 logger = logging.getLogger(__name__)
@@ -35,7 +38,7 @@ def build_impl():
         cdrom_bootstrap_obj.setup()
         setup_chroot_basedir(cdrom_bootstrap_obj)
 
-    image_version = get_image_version()
+    image_version = get_image_version(vendor=TRUENAS_VENDOR)
     logger.debug('Image version identified as %r', image_version)
     logger.debug('Installing packages [ISO] (%s/cdrom-packages.log)', LOG_DIR)
     try:


### PR DESCRIPTION
If the environment variable `TRUENAS_VENDOR` is passed, upon ISO creation we create a `/data/.vendor` file that is JSON encoded, containing a "name" key with the value passed from TRUENAS_VENDOR.