### PR TITLE
NAS-129797 / 24.10 / Add .vendor to ISO

### DIFF
--- a/scale_build/config.py
+++ b/scale_build/config.py
@@ -47,6 +47,7 @@ TRAIN = get_env_variable('TRUENAS_TRAIN', str)
 TRUENAS_BRANCH_OVERRIDE = get_env_variable('TRUENAS_BRANCH_OVERRIDE', str)
 TRY_BRANCH_OVERRIDE = get_env_variable('TRY_BRANCH_OVERRIDE', str)
 VERSION = get_env_variable('TRUENAS_VERSION', str, f'{_VERS}-{BUILD_TIME_OBJ.strftime("%Y%m%d-%H%M%S")}')
+TRUENAS_VENDOR = get_env_variable('TRUENAS_VENDOR', str)
 
 
 # We will get branch overrides and identity file path overrides from here

--- a/scale_build/image/manifest.py
+++ b/scale_build/image/manifest.py
@@ -64,12 +64,13 @@ def build_release_manifest(update_file, update_file_checksum):
         }, f)
 
 
-def get_image_version():
+def get_image_version(vendor=None):
     if not os.path.exists(RELEASE_MANIFEST):
         raise CallError(f'{RELEASE_MANIFEST!r} does not exist')
 
     with open(RELEASE_MANIFEST) as f:
-        return json.load(f)['version']
+        vendor = f'-{vendor}' if vendor else ''
+        return f"{json.load(f)['version']}{vendor}"
 
 
 def update_file_path(version=None):

--- a/scale_build/iso.py
+++ b/scale_build/iso.py
@@ -9,6 +9,7 @@ from .image.iso import install_iso_packages, make_iso_file
 from .image.manifest import get_image_version, update_file_path
 from .utils.logger import LoggingContext
 from .utils.paths import LOG_DIR, RELEASE_DIR
+from .config import TRUENAS_VENDOR
 
 
 logger = logging.getLogger(__name__)
@@ -35,7 +36,7 @@ def build_impl():
         cdrom_bootstrap_obj.setup()
         setup_chroot_basedir(cdrom_bootstrap_obj)
 
-    image_version = get_image_version()
+    image_version = get_image_version(vendor=TRUENAS_VENDOR)
     logger.debug('Image version identified as %r', image_version)
     logger.debug('Installing packages [ISO] (%s/cdrom-packages.log)', LOG_DIR)
     try:

--- a/truenas_install/__main__.py
+++ b/truenas_install/__main__.py
@@ -480,6 +480,9 @@ def main():
 
                     setup_machine_id = configure_serial = True
 
+                    # Copy all files from ISO's data to new root's data (only includes .vendor right now)
+                    run_command(["cp", "-r", "/data/.", f"{root}/data/"])
+
                 # We only want /data itself (without contents) and /data/subsystems to be 755
                 # whereas everything else should be 700
                 # Doing this here is important so that we cover both fresh install and upgrade case


### PR DESCRIPTION
If the environment variable TRUENAS_VENDOR is passed, upon ISO creation we create a /data/.vendor file that is JSON encoded, containing a "name" key with the value passed from TRUENAS_VENDOR.