### PR TITLE
NAS-130269 / 24.10 / remove reference to unused pcm repo

### DIFF
--- a/conf/build.manifest
+++ b/conf/build.manifest
@@ -31,9 +31,6 @@ apt-repos:
   - url: https://apt.sys.truenas.net/electriceel/nightlies/nvidia/
     distribution: bookworm
     component: main
-  - url: https://apt.sys.truenas.net/electriceel/nightlies/pcm/
-    distribution: bookworm
-    component: main
   - url: https://apt.sys.truenas.net/electriceel/nightlies/docker/
     distribution: bookworm
     component: stable


### PR DESCRIPTION
c.f. https://github.com/truenas/middleware/pull/14091 for details.