### PR TITLE
NAS-130350 / 24.10 / Remove nslcd package from build

### DIFF
--- a/conf/build.manifest
+++ b/conf/build.manifest
@@ -96,8 +96,6 @@ base-packages:
   install_recommends: true
 - name: nvidia-kernel
   install_recommends: true
-- name: nslcd
-  install_recommends: true
 - name: nvidia-container-toolkit
   install_recommends: true
 - name: nvidia-smi


### PR DESCRIPTION
We have replaced nslcd with SSSD.