### PR TITLE
NAS-130356 / 24.10 / `intel-gpu-tools`

### DIFF
--- a/conf/build.manifest
+++ b/conf/build.manifest
@@ -308,6 +308,9 @@ additional-packages:
 - name: systemd-container
   comment: requested by community (NAS-123533)
   install_recommends: false
+- name: intel-gpu-tools
+  comment: requested by community (NAS-130356)
+  install_recommends: false
 
 #
 # List of additional packages installed into TrueNAS SCALE ISO file


### PR DESCRIPTION
[NAS-130356](https://ixsystems.atlassian.net/browse/NAS-130356): Adding `intel-gpu-tools` package at community request.

Passed all tests except `test_system_general_ui_rollback.test_system_general_ui_rollback`.
http://jenkins.eng.ixsystems.net:8080/job/master/job/api_tests/1760/