### PR TITLE
NAS-130351 / 24.10 / clean `/var/trash`

### DIFF
--- a/scale_build/image/update.py
+++ b/scale_build/image/update.py
@@ -193,6 +193,7 @@ def clean_rootfs():
         os.path.join(CHROOT_BASEDIR, 'usr/share/doc'),
         os.path.join(CHROOT_BASEDIR, 'var/cache/apt'),
         os.path.join(CHROOT_BASEDIR, 'var/lib/apt/lists'),
+        os.path.join(CHROOT_BASEDIR, 'var/trash'),
     ):
         shutil.rmtree(path)
         os.makedirs(path, exist_ok=True)


### PR DESCRIPTION
[NAS-130351](https://ixsystems.atlassian.net/browse/NAS-130351): Cleaning out /var/trash package diversions.

API tests: http://jenkins.eng.ixsystems.net:8080/job/master/job/api_tests/1769/