### PR TITLE
NAS-130395 / 24.10 / Add nscd to base build

### DIFF
--- a/conf/build.manifest
+++ b/conf/build.manifest
@@ -108,6 +108,8 @@ base-packages:
   install_recommends: true
 - name: linux-cpupower
   install_recommends: true
+- name: nscd
+  install_recommends: true
 - name: truenas-samba
   install_recommends: true
 - name: truenas-sssd

--- a/conf/build.manifest
+++ b/conf/build.manifest
@@ -109,7 +109,7 @@ base-packages:
 - name: linux-cpupower
   install_recommends: true
 - name: nscd
-  install_recommends: true
+  install_recommends: false
 - name: truenas-samba
   install_recommends: true
 - name: truenas-sssd


### PR DESCRIPTION
This was originally installed as a recommended package for nslcd, and so
it must be re-added now that nslcd is no longer included in base packages.