### PR TITLE
NAS-130370 / 24.10 / Bring in golang from bookworm-backports

### DIFF
--- a/conf/build.manifest
+++ b/conf/build.manifest
@@ -203,7 +203,7 @@ apt_preferences:
 - Package: "*curl*"
   Pin: "release n=bookworm-security"
   Pin-Priority: 1000
-- Package: "golang"
+- Package: "golang*"
   Pin: "release n=bookworm-backports"
   Pin-Priority: 1000
 - Package: "*libc-*"

--- a/conf/build.manifest
+++ b/conf/build.manifest
@@ -203,6 +203,9 @@ apt_preferences:
 - Package: "*curl*"
   Pin: "release n=bookworm-security"
   Pin-Priority: 1000
+- Package: "golang"
+  Pin: "release n=bookworm-backports"
+  Pin-Priority: 1000
 - Package: "*libc-*"
   Pin: "release n=bookworm-security"
   Pin-Priority: 1000


### PR DESCRIPTION
This PR adds changes to bring golang from bookworm-backports because we need newer version i.e 1.22 of golang to build rclone which is not otherwise available in stable.