### PR TITLE
NAS-130580 / 25.04 / Specify libarchive-tools is required to build SCALE

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ In addition to the host, you will want to pre-install the following packages:
 * squashfs-tools
 * rsync
 * unzip
+* libarchive-tools
 
 ``` % sudo apt install build-essential debootstrap git python3-pip python3-venv squashfs-tools unzip libjson-perl rsync```
 


### PR DESCRIPTION
This commit adds changes to specify that libarchive-tools is required to build scale as we use a util which this provides i.e bsdtar in generating mtree of critical datasets.