### PR TITLE
TEN-1474 Option added to prevent deletion of ISO files during Make

### DIFF
--- a/scale_build/config.py
+++ b/scale_build/config.py
@@ -48,6 +48,7 @@ TRUENAS_BRANCH_OVERRIDE = get_env_variable('TRUENAS_BRANCH_OVERRIDE', str)
 TRY_BRANCH_OVERRIDE = get_env_variable('TRY_BRANCH_OVERRIDE', str)
 VERSION = get_env_variable('TRUENAS_VERSION', str, f'{_VERS}-{BUILD_TIME_OBJ.strftime("%Y%m%d-%H%M%S")}')
 TRUENAS_VENDOR = get_env_variable('TRUENAS_VENDOR', str)
+PRESERVE_ISO =  get_env_variable('PRESERVE_ISO', bool)
 
 
 # We will get branch overrides and identity file path overrides from here

--- a/scale_build/config.py
+++ b/scale_build/config.py
@@ -48,7 +48,7 @@ TRUENAS_BRANCH_OVERRIDE = get_env_variable('TRUENAS_BRANCH_OVERRIDE', str)
 TRY_BRANCH_OVERRIDE = get_env_variable('TRY_BRANCH_OVERRIDE', str)
 VERSION = get_env_variable('TRUENAS_VERSION', str, f'{_VERS}-{BUILD_TIME_OBJ.strftime("%Y%m%d-%H%M%S")}')
 TRUENAS_VENDOR = get_env_variable('TRUENAS_VENDOR', str)
-PRESERVE_ISO = get_env_variable('PRESERVE_ISO', bool)
+PRESERVE_ISO = get_env_variable('PRESERVE_ISO', bool, False)
 
 
 # We will get branch overrides and identity file path overrides from here

--- a/scale_build/config.py
+++ b/scale_build/config.py
@@ -48,7 +48,7 @@ TRUENAS_BRANCH_OVERRIDE = get_env_variable('TRUENAS_BRANCH_OVERRIDE', str)
 TRY_BRANCH_OVERRIDE = get_env_variable('TRY_BRANCH_OVERRIDE', str)
 VERSION = get_env_variable('TRUENAS_VERSION', str, f'{_VERS}-{BUILD_TIME_OBJ.strftime("%Y%m%d-%H%M%S")}')
 TRUENAS_VENDOR = get_env_variable('TRUENAS_VENDOR', str)
-PRESERVE_ISO =  get_env_variable('PRESERVE_ISO', bool)
+PRESERVE_ISO = get_env_variable('PRESERVE_ISO', bool)
 
 
 # We will get branch overrides and identity file path overrides from here

--- a/scale_build/image/iso.py
+++ b/scale_build/image/iso.py
@@ -14,6 +14,8 @@ from scale_build.utils.manifest import get_manifest
 from scale_build.utils.run import run
 from scale_build.utils.paths import CD_DIR, CD_FILES_DIR, CHROOT_BASEDIR, CONF_GRUB, PKG_DIR, RELEASE_DIR, TMP_DIR
 from scale_build.config import TRUENAS_VENDOR
+from scale_build.config import PRESERVE_ISO
+
 
 from .bootstrap import umount_chroot_basedir
 from .manifest import get_image_version, update_file_path
@@ -45,8 +47,9 @@ def install_iso_packages_impl():
 
 
 def make_iso_file():
-    for f in glob.glob(os.path.join(RELEASE_DIR, '*.iso*')):
-        os.unlink(f)
+    if PRESERVE_ISO:
+        for f in glob.glob(os.path.join(RELEASE_DIR, '*.iso*')):
+            os.unlink(f)
 
     # Set default PW to root
     run(fr'chroot {CHROOT_BASEDIR} /bin/bash -c "echo -e \"root\nroot\" | passwd root"', shell=True)

--- a/scale_build/image/iso.py
+++ b/scale_build/image/iso.py
@@ -16,7 +16,6 @@ from scale_build.utils.paths import CD_DIR, CD_FILES_DIR, CHROOT_BASEDIR, CONF_G
 from scale_build.config import TRUENAS_VENDOR
 from scale_build.config import PRESERVE_ISO
 
-
 from .bootstrap import umount_chroot_basedir
 from .manifest import get_image_version, update_file_path
 from .utils import run_in_chroot

--- a/scale_build/image/iso.py
+++ b/scale_build/image/iso.py
@@ -47,7 +47,7 @@ def install_iso_packages_impl():
 
 
 def make_iso_file():
-    if PRESERVE_ISO:
+    if not PRESERVE_ISO:
         for f in glob.glob(os.path.join(RELEASE_DIR, '*.iso*')):
             os.unlink(f)
 


### PR DESCRIPTION
Update to allow both standard and vendor ISO to be produced from a pipeline without the iso which is generated first being deleted.