### PR TITLE
NAS-130832 / 24.10-RC.1 / Preserve the syslog-ng.persist file on upgrades (by anodos325)

### DIFF
--- a/truenas_install/__main__.py
+++ b/truenas_install/__main__.py
@@ -450,6 +450,8 @@ def main():
                         rsync.append("var/lib/libvirt/qemu/nvram")
                     if os.path.exists(f"{old_root}/var/lib/netdata"):
                         rsync.append("var/lib/netdata")
+                    if os.path.exists(f"{old_root}/var/lib/syslog-ng/syslog-ng.persist"):
+                        rsync.append("var/lib/syslog-ng/syslog-ng.persist")
                     if "var/log" not in cloned_datasets:
                         try:
                             logs = os.listdir(f"{old_root}/var/log")

--- a/truenas_install/fhs.py
+++ b/truenas_install/fhs.py
@@ -93,7 +93,8 @@ TRUENAS_DATASETS = [
     {
         'name':  'audit',
         'options': ['NOSUID', 'NOEXEC', 'NOATIME', 'NOACL'],
-        'mode': 0o700
+        'mode': 0o700,
+        'clone': True,
     },
     {
         'name':  'conf',


### PR DESCRIPTION
The syslog-ng.persist file contains information about last read systemd journal message which will prevent duplicate audit table insertions and sending duplicate messages to remote syslog server.

This commit also switches our default to clone the audit dataset forward on upgrade.

Original PR: https://github.com/truenas/scale-build/pull/701
Jira URL: https://ixsystems.atlassian.net/browse/NAS-130832