### PR TITLE
NAS-130821 / 24.10.0 / Remove noexec permission for /etc

### DIFF
--- a/truenas_install/fhs.py
+++ b/truenas_install/fhs.py
@@ -114,7 +114,7 @@ TRUENAS_DATASETS = [
     },
     {
         'name':  'etc',
-        'options': ['NOSUID', 'NOACL', 'NOEXEC'],
+        'options': ['NOSUID', 'NOACL'],
         'snap': True
     },
     {


### PR DESCRIPTION
grub2 installs config generation scripts under `/etc/grub.d/`. If `update-grub` cannot run those scripts, config generation fails and update-grub errors out.

We should remove `noexec` for `etc` dataset. There has been an upstream ZFS fix that enforces the correct mount options for Linux runtime. To enable that patch, we should first remove `noexec `permission for `/etc`, otherwise installation would break.

Upstream PR: https://github.com/openzfs/zfs/pull/16393