### PR TITLE
NAS-131125 / 24.10.0 / Do not clone systemd journal on upgrade (by anodos325) (by bugclerk)

### DIFF
--- a/truenas_install/fhs.py
+++ b/truenas_install/fhs.py
@@ -150,7 +150,11 @@ TRUENAS_DATASETS = [
     },
     {
         'name':  'var/log',
-        'options': ['NOSUID', 'NOEXEC', 'POSIXACL', 'NOATIME'],
+        'options': ['NOSUID', 'NOEXEC', 'NOACL', 'NOATIME'],
         'clone': True,
+    },
+    {
+        'name':  'var/log/journal',
+        'options': ['NOSUID', 'NOEXEC', 'POSIXACL', 'NOATIME'],
     },
 ]


### PR DESCRIPTION
During the upgrade process its possible for the syslog-ng cursor for the systemd journal to advance beyond what is present in the newly cloned logs dataset. This results in syslog-ng re-reading the same messages and sending them a second time to remote syslog servers, our audit databases, and local files.

For typical purposes the systemd journal is treated as ephemeral data, but is not something we want to lose on reboot or upgrade. This means that volatile storage is undesirable. As a compromise solution that absolutely prevents duplicate entries we have settled on creating a new dedicated systemd journal dataset on upgrades. The old journal contents dataset are preserved in the previous boot environment.

This has the added advantage of allowing us to disable ACL support on the logs dataset.

Original PR: https://github.com/truenas/scale-build/pull/711
Jira URL: https://ixsystems.atlassian.net/browse/NAS-131125

Original PR: https://github.com/truenas/scale-build/pull/712
Jira URL: https://ixsystems.atlassian.net/browse/NAS-131125