### PR TITLE
NAS-131234 / 24.10.0 / pull in latest firmware-linux package from bookworm backports (by yocalebo)

### DIFF
--- a/conf/build.manifest
+++ b/conf/build.manifest
@@ -189,6 +189,9 @@ apt_preferences:
 - Package: "*curl*"
   Pin: "release n=bookworm-security"
   Pin-Priority: 1000
+- Package: "*firmware*"
+  Pin: "release n=bookworm-backports"
+  Pin-Priority: 1000
 - Package: "golang*"
   Pin: "release n=bookworm-backports"
   Pin-Priority: 1000


### PR DESCRIPTION
In https://github.com/truenas/binaries/pull/5 we manually added the missing binary firmware file to fix Intel ARC gpu transcoding. We did not, however, add this to EE because by the time we released EE the upstream package should have included this file.

What we neglected to do was prioritize the bookworm-backports repo for this package so we're pulling an ancient version (20230210-5) when the version in backports is 20240709-2~bpo12+1. Outside of this specific reason, pulling in the latest package also includes latest intel/amd64 microcode which fixes all kinds of fun things (cve, stability, performance, etc) for cpu firmware.

Original PR: https://github.com/truenas/scale-build/pull/720
Jira URL: https://ixsystems.atlassian.net/browse/NAS-131234