### PR TITLE
NAS-131338 / 24.10-RC.1 / Bring in non-free firmware for debian backports (by sonicaj)

### DIFF
--- a/conf/build.manifest
+++ b/conf/build.manifest
@@ -17,7 +17,7 @@ apt-repos:
     component: main
   - url: https://apt.sys.truenas.net/electriceel/24.10-RC.1/debian-backports/
     distribution: bookworm-backports
-    component: "main contrib non-free"
+    component: "main contrib non-free non-free-firmware"
   - url: https://apt.sys.truenas.net/electriceel/24.10-RC.1/debian-debug/
     distribution: bookworm-debug
     component: main


### PR DESCRIPTION
Automatic cherry-pick failed. Please resolve conflicts by running:

    git reset --hard HEAD~1
    git cherry-pick -x 8e35a07b3af063e66ca45e97aec21dd5a1406b1f

If the original PR was merged via a squash, you can just cherry-pick the squashed commit:

    git reset --hard HEAD~1
    git cherry-pick -x 2f97e32b3069346445e91d6f7f44d62c2a83cecd



Original PR: https://github.com/truenas/scale-build/pull/725
Jira URL: https://ixsystems.atlassian.net/browse/NAS-131338