### PR TITLE
NAS-131346 / 25.04 / fix master build

### DIFF
--- a/conf/build.manifest
+++ b/conf/build.manifest
@@ -197,12 +197,6 @@ apt_preferences:
 - Package: "golang*"
   Pin: "release n=bookworm-backports"
   Pin-Priority: 1000
-- Package: "*libc-*"
-  Pin: "release n=bookworm-security"
-  Pin-Priority: 1000
-- Package: "*libc6*"
-  Pin: "release n=bookworm-security"
-  Pin-Priority: 1000
 - Package: "*libcrypto*"
   Pin: "origin \"\""
   Pin-Priority: 1050


### PR DESCRIPTION
We recently updated master apt servers which has broken the build. The libc* dependencies that come from the bookworm-security are now older than what is provided in the standard repo. The bookworm-security pulls in version 2.36-9+deb12u7. By removing these entries, the version that is pulled in is 2.36-9+deb12u8.