### PR TITLE
NAS-131352 / 25.04 / Add explicit openssl dependency for swagger

### DIFF
--- a/conf/build.manifest
+++ b/conf/build.manifest
@@ -573,6 +573,8 @@ sources:
 - name: swagger
   repo: https://github.com/truenas/swagger
   branch: main
+  explicit_deps:
+    - openssl
 - name: truenas
   repo: https://github.com/truenas/middleware
   branch: master


### PR DESCRIPTION
This commit adds an explicit openssl dependency for swagger as swagger brings in npm for build-depends which in turn needs libssl and friends which will error out if there is a mismatch of libssl versions (that is a separate bug ofc) but the point is that swagger depends on openssl so we should mark it as such.