### PR TITLE
NAS-131449 / 25.04 / fix bug in deprecated service detection

### DIFF
--- a/truenas_install/__main__.py
+++ b/truenas_install/__main__.py
@@ -202,12 +202,12 @@ def precheck(old_root):
 
                         try:
                             with open(f"/proc/{pid}/cgroup") as f:
-                                cgroups = f.read()
+                                cgroups = f.read().strip()
                         except FileNotFoundError:
                             cgroups = ""
 
                         # https://forums.truenas.com/t/disable-webdav-service-from-cli-or-by-modifying-config-db/2795/4
-                        if "docker" in cgroups or "/payload/" in cgroups:
+                        if cgroups and "kubepods" in cgroups or "docker" in cgroups or "/payload/" in cgroups:
                             continue
 
                         running_services.append(title)


### PR DESCRIPTION
I'm not even really sure how this has worked in the first place....QE has a system (running 24.04.2.2) with a Gold license that they're manually upgrading to what will be EE-RC.1. They're met with a deprecation message and the update fails. After investigation, I'm not sure how this has ever worked....

The system they had was running minio which produced a running service name of  `minio` but the crgroup entry was
```
0::/kubepods.slice/kubepods-burstable.slice/kubepods-burstable pod3c3941c1_24e7_4189_854f_f9dfcfa638ef.slice/cri-containerd-14ef8d9c8a76f8c8f1731bd455062481c4e03f683fe52566bbc4fc74f480225.scope
```

I went ahead and installed webdav app and also saw it produce an entry like so
```
0::/kubepods.slice/kubepods-burstable.slice/kubepods-burstable-podf905dab1_0a2c_4e68_9d0c_861da1874869.slice/cri-containerd-660a2b0eb91bc45f92b245099be5b2d27686d2e29329bc2eeeedc8f4a0b951e0.scope
```

This means we're tripping the deprecation service logic rather easily and after looking at it for a bit, I'm not sure how we were ever doing this properly :thinking: Anyways, I've added the `kubepod` string as another check to prevent these false positive alerts.