### PR TITLE
Create /var/lib/incus with "dev"

### DIFF
--- a/truenas_install/__main__.py
+++ b/truenas_install/__main__.py
@@ -315,6 +315,8 @@ def main():
                 options.extend(["-o", "exec=off"])
             if "NODEV" in entry["options"]:
                 options.extend(["-o", "devices=off"])
+            if "DEV" in entry["options"]:
+                options.extend(["-o", "devices=on"])
             if "NOACL" in entry['options']:
                 options.extend(["-o", "acltype=off", "-o", "aclmode=discard"])
             if "POSIXACL" in entry["options"]:

--- a/truenas_install/fhs.py
+++ b/truenas_install/fhs.py
@@ -33,6 +33,7 @@ NOACL - sets acltype=off.
 NOATIME - sets atime=off.
 RO - sets readonly=on.
 NODEV - sets devices=off
+DEV - sets devices=on
 
 DATASETS
 --------------
@@ -147,6 +148,16 @@ TRUENAS_DATASETS = [
         'name':  'var/ca-certificates',
         'options': ['NOSUID', 'NOACL', 'NOEXEC'],
         'mountpoint': '/var/local/ca-certificates'
+    },
+    {
+        'name':  'var/lib',
+        'options': ['NOSUID', 'NOACL', 'NOATIME'],
+        'snap': True
+    },
+    {
+        'name':  'var/lib/incus',
+        'options': ['NOSUID', 'NOACL', 'NOATIME', 'DEV'],
+        'snap': True
     },
     {
         'name':  'var/log',


### PR DESCRIPTION
Recent fix in ZFS enforced nodev to work. Incus won't allow attaching devices to container unless it can create devices within /var/lib/incus.