### PR TITLE
NAS-131695 / 25.04 / Change default libvirt uid/gid

### DIFF
--- a/conf/reference-files/etc/group
+++ b/conf/reference-files/etc/group
@@ -75,7 +75,7 @@ webdav:x:666:
 truenas_readonly_administrators:x:951:
 truenas_sharing_administrators:x:952:
 docker:x:999:
-libvirt-qemu:x:64055:libvirt-qemu
+libvirt-qemu:x:986:libvirt-qemu
 haproxy:x:130:
 uuidd:x:131:
 i2c:x:132:

--- a/conf/reference-files/etc/passwd
+++ b/conf/reference-files/etc/passwd
@@ -42,7 +42,7 @@ ladvd:x:124:127:ladvd user:/var/empty:/usr/sbin/nologin
 nova:x:125:129::/var/lib/nova:/bin/bash
 apps:x:568:568:Unprivileged Apps User:/var/empty:/usr/sbin/nologin
 webdav:x:666:666:WebDAV Anonymous User:/var/empty:/usr/sbin/nologin
-libvirt-qemu:x:64055:106:Libvirt Qemu,,,:/var/lib/libvirt:/usr/sbin/nologin
+libvirt-qemu:x:986:106:Libvirt Qemu,,,:/var/lib/libvirt:/usr/sbin/nologin
 haproxy:x:126:130::/var/lib/haproxy:/usr/sbin/nologin
 uuidd:x:127:131::/run/uuidd:/usr/sbin/nologin
 ntpsec:x:128:135::/nonexistent:/usr/sbin/nologin

--- a/truenas_install/__main__.py
+++ b/truenas_install/__main__.py
@@ -500,6 +500,12 @@ def main():
                 for entry in TRUENAS_DATA_HIERARCHY:
                     entry_path = os.path.join(root, entry["path"])
                     os.makedirs(entry_path, exist_ok=True)
+                    if owner_config := entry.get("owner"):
+                        run_command([
+                            "chown", *(["-R"] if entry["recursive_ownership"] else []),
+                            f"{owner_config['uid']}:{owner_config['gid']}", entry_path
+                        ])
+
                     if mode := entry.get("mode"):
                         mode = f"u={mode['user']},g={mode['group']},o={mode['other']}"
                         run_command(["chmod", *(["-R"] if entry["recursive"] else []), mode, entry_path])

--- a/truenas_install/dhs.py
+++ b/truenas_install/dhs.py
@@ -15,13 +15,25 @@ TRUENAS_DATA_HIERARCHY_SCHEMA = {
                 'required': ['user', 'group', 'other'],
                 'additionalProperties': False,
             },
+            'owner': {
+                'type': 'object',
+                'properties': {
+                    'uid': {'type': 'integer'},
+                    'gid': {'type': 'integer'},
+                },
+                'required': ['uid', 'gid'],
+                'additionalProperties': False,
+            },
             'recursive': {'type': 'boolean'},
+            'recursive_ownership': {'type': 'boolean'},
         },
         'required': ['path'],
         'additionalProperties': False,
         'dependencies': {
             'recursive': ['mode'],
-            'mode': ['recursive']
+            'mode': ['recursive'],
+            'owner': ['recursive_ownership'],
+            'recursive_ownership': ['owner'],
         },
     }
 }
@@ -51,6 +63,11 @@ TRUENAS_DATA_HIERARCHY = [
     },
     {
         'path': 'data/subsystems/vm/nvram',
+        'owner': {
+            'uid': 986,
+            'gid': 986,
+        },
+        'recursive_ownership': True,
     },
     {
         'path': 'data/zfs',


### PR DESCRIPTION
## Context

After talking with Andrew, we decided to change libvirt's default uid/gid as it has a high potential for a clash with the default uid/gid in place. A uid/gid has been chosen for libvirt which is under 1000 and reduces a potential clash with a user configured uid/gid.