### PR TITLE
NAS-131327 / 25.04 / use smartmontools from custom repo

### DIFF
--- a/conf/build.manifest
+++ b/conf/build.manifest
@@ -218,9 +218,6 @@ apt_preferences:
 - Package: "*polkit*"
   Pin: "release n=bookworm-security"
   Pin-Priority: 1000
-- Package: "smartmontools"
-  Pin: "release n=bookworm-backports"
-  Pin-Priority: 1000
 - Package: "*ssh*"
   Pin: "release n=bookworm-security"
   Pin-Priority: 1000
@@ -632,3 +629,12 @@ sources:
 - name: py_sg3
   repo: https://github.com/truenas/py-sg3
   branch: master
+- name: smartmontools
+  repo: https://github.com/truenas/smartmontools
+  branch: master
+  debian_fork: true
+  predepscmd:
+    - "apt install -y wget xz-utils"
+    - "./pull.sh"
+  deoptions: nocheck
+  generate_version: false


### PR DESCRIPTION
Switch to a local repository for `smartmontools` to incorporate the fixes for [NAS-131327](https://ixsystems.atlassian.net/browse/NAS-131327) and [NAS-131181](https://ixsystems.atlassian.net/browse/NAS-131181).
Scale Build: http://jenkins.eng.ixsystems.net:8080/job/master/job/custom/701/