### PR TITLE
NAS-131327 / 24.10.1 / use smartmontools from custom repo (by ixhamza)

### DIFF
--- a/conf/build.manifest
+++ b/conf/build.manifest
@@ -219,9 +219,6 @@ apt_preferences:
 - Package: "*polkit*"
   Pin: "release n=bookworm-security"
   Pin-Priority: 1000
-- Package: "smartmontools"
-  Pin: "release n=bookworm-backports"
-  Pin-Priority: 1000
 - Package: "*ssh*"
   Pin: "release n=bookworm-security"
   Pin-Priority: 1000
@@ -631,3 +628,12 @@ sources:
 - name: py_sg3
   repo: https://github.com/truenas/py-sg3
   branch: stable/electriceel
+- name: smartmontools
+  repo: https://github.com/truenas/smartmontools
+  branch: master
+  debian_fork: true
+  predepscmd:
+    - "apt install -y wget xz-utils"
+    - "./pull.sh"
+  deoptions: nocheck
+  generate_version: false


### PR DESCRIPTION
Switch to a local repository for `smartmontools` to incorporate the fixes for [NAS-131327](https://ixsystems.atlassian.net/browse/NAS-131327) and [NAS-131181](https://ixsystems.atlassian.net/browse/NAS-131181).
Scale Build: http://jenkins.eng.ixsystems.net:8080/job/master/job/custom/701/

Original PR: https://github.com/truenas/scale-build/pull/750
Jira URL: https://ixsystems.atlassian.net/browse/NAS-131327