### PR TITLE
NAS-132446 / 25.04 / Initial add of option to use internal APT repo for builds

### DIFF
--- a/conf/build.manifest
+++ b/conf/build.manifest
@@ -8,23 +8,25 @@ identity_file_path_default: "~/.ssh/id_rsa"
 # into the build chroots, or the final system images.
 ############################################################################
 apt-repos:
-  url: https://apt.sys.truenas.net/fangtooth/nightlies/debian/
+  base-url: https://apt.sys.truenas.net
+  base-url-internal: http://apt-mirror.tn.ixsystems.net
+  url: /fangtooth/nightlies/debian/
   distribution: bookworm
   components: main
   additional:
-  - url: https://apt.sys.truenas.net/fangtooth/nightlies/debian-security/
+  - url: /fangtooth/nightlies/debian-security/
     distribution: bookworm-security
     component: main
-  - url: https://apt.sys.truenas.net/fangtooth/nightlies/debian-backports/
+  - url: /fangtooth/nightlies/debian-backports/
     distribution: bookworm-backports
     component: "main contrib non-free non-free-firmware"
-  - url: https://apt.sys.truenas.net/fangtooth/nightlies/debian-debug/
+  - url: /fangtooth/nightlies/debian-debug/
     distribution: bookworm-debug
     component: main
-  - url: https://apt.sys.truenas.net/fangtooth/nightlies/yarn/
+  - url: /fangtooth/nightlies/yarn/
     distribution: stable
     component: main
-  - url: https://apt.sys.truenas.net/fangtooth/nightlies/docker/
+  - url: /fangtooth/nightlies/docker/
     distribution: bookworm
     component: stable
     key: keys/docker.gpg

--- a/scale_build/bootstrap/bootstrapdir.py
+++ b/scale_build/bootstrap/bootstrapdir.py
@@ -3,7 +3,7 @@ import os
 import shutil
 
 from scale_build.clean import clean_packages
-from scale_build.utils.manifest import apt_get_base_url, get_manifest
+from scale_build.utils.manifest import get_apt_base_url, get_manifest
 from scale_build.utils.paths import BUILDER_DIR, CHROOT_BASEDIR, REFERENCE_FILES, REFERENCE_FILES_DIR
 from scale_build.utils.run import run
 
@@ -46,7 +46,7 @@ class BootstrapDir(CacheMixin, HashMixin):
 
         self.add_trusted_apt_key()
         apt_repos = get_manifest()['apt-repos']
-        apt_base_url = apt_get_base_url()
+        apt_base_url = get_apt_base_url()
         self.debootstrap_debian()
         self.setup_mounts()
 

--- a/scale_build/bootstrap/bootstrapdir.py
+++ b/scale_build/bootstrap/bootstrapdir.py
@@ -3,7 +3,7 @@ import os
 import shutil
 
 from scale_build.clean import clean_packages
-from scale_build.utils.manifest import APT_BASE_URL, get_manifest
+from scale_build.utils.manifest import apt_get_base_url, get_manifest
 from scale_build.utils.paths import BUILDER_DIR, CHROOT_BASEDIR, REFERENCE_FILES, REFERENCE_FILES_DIR
 from scale_build.utils.run import run
 
@@ -46,6 +46,7 @@ class BootstrapDir(CacheMixin, HashMixin):
 
         self.add_trusted_apt_key()
         apt_repos = get_manifest()['apt-repos']
+        apt_base_url = apt_get_base_url()
         self.debootstrap_debian()
         self.setup_mounts()
 
@@ -61,7 +62,7 @@ class BootstrapDir(CacheMixin, HashMixin):
         run(['chroot', self.chroot_basedir, 'apt', 'install', '-y', 'gnupg'])
 
         # Save the correct repo in sources.list
-        apt_sources = [f'deb {APT_BASE_URL}{apt_repos["url"]} {apt_repos["distribution"]} {apt_repos["components"]}']
+        apt_sources = [f'deb {apt_base_url}{apt_repos["url"]} {apt_repos["distribution"]} {apt_repos["components"]}']
 
         # Add additional repos
         for repo in apt_repos['additional']:
@@ -71,7 +72,7 @@ class BootstrapDir(CacheMixin, HashMixin):
                 run(['chroot', self.chroot_basedir, 'apt-key', 'add', '/apt.key'])
                 os.unlink(os.path.join(self.chroot_basedir, 'apt.key'))
 
-            apt_sources.append(f'deb {APT_BASE_URL}{repo["url"]} {repo["distribution"]} {repo["component"]}')
+            apt_sources.append(f'deb {apt_base_url}{repo["url"]} {repo["distribution"]} {repo["component"]}')
 
         with open(apt_sources_path, 'w') as f:
             f.write('\n'.join(apt_sources))

--- a/scale_build/bootstrap/bootstrapdir.py
+++ b/scale_build/bootstrap/bootstrapdir.py
@@ -30,11 +30,12 @@ class BootstrapDir(CacheMixin, HashMixin):
 
     def debootstrap_debian(self):
         manifest = get_manifest()
+        apt_base_url = get_apt_base_url()
         run(
             ['debootstrap'] + self.deopts + [
                 '--keyring', '/etc/apt/trusted.gpg.d/debian-archive-truenas-automatic.gpg',
                 manifest['debian_release'],
-                self.chroot_basedir, manifest['apt-repos']['url']
+                self.chroot_basedir, apt_base_url + manifest['apt-repos']['url']
             ]
         )
 

--- a/scale_build/bootstrap/bootstrapdir.py
+++ b/scale_build/bootstrap/bootstrapdir.py
@@ -3,7 +3,7 @@ import os
 import shutil
 
 from scale_build.clean import clean_packages
-from scale_build.utils.manifest import APT_BASE_URL get_manifest
+from scale_build.utils.manifest import APT_BASE_URL, get_manifest
 from scale_build.utils.paths import BUILDER_DIR, CHROOT_BASEDIR, REFERENCE_FILES, REFERENCE_FILES_DIR
 from scale_build.utils.run import run
 

--- a/scale_build/bootstrap/bootstrapdir.py
+++ b/scale_build/bootstrap/bootstrapdir.py
@@ -3,7 +3,7 @@ import os
 import shutil
 
 from scale_build.clean import clean_packages
-from scale_build.utils.manifest import get_manifest
+from scale_build.utils.manifest import APT_BASE_URL get_manifest
 from scale_build.utils.paths import BUILDER_DIR, CHROOT_BASEDIR, REFERENCE_FILES, REFERENCE_FILES_DIR
 from scale_build.utils.run import run
 
@@ -61,7 +61,7 @@ class BootstrapDir(CacheMixin, HashMixin):
         run(['chroot', self.chroot_basedir, 'apt', 'install', '-y', 'gnupg'])
 
         # Save the correct repo in sources.list
-        apt_sources = [f'deb {apt_repos["url"]} {apt_repos["distribution"]} {apt_repos["components"]}']
+        apt_sources = [f'deb {APT_BASE_URL}{apt_repos["url"]} {apt_repos["distribution"]} {apt_repos["components"]}']
 
         # Add additional repos
         for repo in apt_repos['additional']:
@@ -71,7 +71,7 @@ class BootstrapDir(CacheMixin, HashMixin):
                 run(['chroot', self.chroot_basedir, 'apt-key', 'add', '/apt.key'])
                 os.unlink(os.path.join(self.chroot_basedir, 'apt.key'))
 
-            apt_sources.append(f'deb {repo["url"]} {repo["distribution"]} {repo["component"]}')
+            apt_sources.append(f'deb {APT_BASE_URL}{repo["url"]} {repo["distribution"]} {repo["component"]}')
 
         with open(apt_sources_path, 'w') as f:
             f.write('\n'.join(apt_sources))

--- a/scale_build/bootstrap/bootstrapdir.py
+++ b/scale_build/bootstrap/bootstrapdir.py
@@ -47,6 +47,7 @@ class BootstrapDir(CacheMixin, HashMixin):
         self.add_trusted_apt_key()
         apt_repos = get_manifest()['apt-repos']
         apt_base_url = get_apt_base_url()
+        logger.info('Using apt base url (%s)', apt_base_url)
         self.debootstrap_debian()
         self.setup_mounts()
 

--- a/scale_build/bootstrap/bootstrapdir.py
+++ b/scale_build/bootstrap/bootstrapdir.py
@@ -47,7 +47,6 @@ class BootstrapDir(CacheMixin, HashMixin):
         self.add_trusted_apt_key()
         apt_repos = get_manifest()['apt-repos']
         apt_base_url = get_apt_base_url()
-        logger.info('Using apt base url (%s)', apt_base_url)
         self.debootstrap_debian()
         self.setup_mounts()
 
@@ -149,11 +148,12 @@ class RootfsBootstrapDir(BootstrapDir):
 
     def debootstrap_debian(self):
         manifest = get_manifest()
+        apt_base_url = get_apt_base_url()
         run(
             ['debootstrap'] + self.deopts + [
                 '--foreign', '--keyring', '/etc/apt/trusted.gpg.d/debian-archive-truenas-automatic.gpg',
                 manifest['debian_release'],
-                self.chroot_basedir, manifest['apt-repos']['url']
+                self.chroot_basedir, apt_base_url + manifest['apt-repos']['url']
             ]
         )
         for reference_file in REFERENCE_FILES:

--- a/scale_build/bootstrap/hash.py
+++ b/scale_build/bootstrap/hash.py
@@ -6,7 +6,7 @@ import re
 import requests
 import urllib.parse
 
-from scale_build.utils.manifest import APT_BASE_URL get_manifest
+from scale_build.utils.manifest import APT_BASE_URL, get_manifest
 from scale_build.utils.run import run
 from scale_build.utils.paths import CACHE_DIR, HASH_DIR
 

--- a/scale_build/bootstrap/hash.py
+++ b/scale_build/bootstrap/hash.py
@@ -6,7 +6,7 @@ import re
 import requests
 import urllib.parse
 
-from scale_build.utils.manifest import apt_get_base_url, get_manifest
+from scale_build.utils.manifest import get_apt_base_url, get_manifest
 from scale_build.utils.run import run
 from scale_build.utils.paths import CACHE_DIR, HASH_DIR
 
@@ -27,7 +27,7 @@ def get_repo_hash(repo_url, distribution):
 
 def get_all_repo_hash():
     apt_repos = get_manifest()['apt-repos']
-    apt_base_url = apt_get_base_url()
+    apt_base_url = get_apt_base_url()
     # Start by validating the main APT repo
     all_repo_hash = get_repo_hash(apt_base_url + apt_repos['url'], apt_repos['distribution'])
 

--- a/scale_build/bootstrap/hash.py
+++ b/scale_build/bootstrap/hash.py
@@ -6,7 +6,7 @@ import re
 import requests
 import urllib.parse
 
-from scale_build.utils.manifest import APT_BASE_URL, get_manifest
+from scale_build.utils.manifest import apt_get_base_url, get_manifest
 from scale_build.utils.run import run
 from scale_build.utils.paths import CACHE_DIR, HASH_DIR
 
@@ -27,11 +27,12 @@ def get_repo_hash(repo_url, distribution):
 
 def get_all_repo_hash():
     apt_repos = get_manifest()['apt-repos']
+    apt_base_url = apt_get_base_url()
     # Start by validating the main APT repo
-    all_repo_hash = get_repo_hash(APT_BASE_URL + apt_repos['url'], apt_repos['distribution'])
+    all_repo_hash = get_repo_hash(apt_base_url + apt_repos['url'], apt_repos['distribution'])
 
     for repo_config in apt_repos['additional']:
-        all_repo_hash += get_repo_hash(APT_BASE_URL + repo_config['url'], repo_config['distribution'])
+        all_repo_hash += get_repo_hash(apt_base_url + repo_config['url'], repo_config['distribution'])
 
     all_repo_hash += hashlib.sha256(get_apt_preferences().encode()).hexdigest()
 

--- a/scale_build/bootstrap/hash.py
+++ b/scale_build/bootstrap/hash.py
@@ -6,7 +6,7 @@ import re
 import requests
 import urllib.parse
 
-from scale_build.utils.manifest import get_manifest
+from scale_build.utils.manifest import APT_BASE_URL get_manifest
 from scale_build.utils.run import run
 from scale_build.utils.paths import CACHE_DIR, HASH_DIR
 
@@ -28,10 +28,10 @@ def get_repo_hash(repo_url, distribution):
 def get_all_repo_hash():
     apt_repos = get_manifest()['apt-repos']
     # Start by validating the main APT repo
-    all_repo_hash = get_repo_hash(apt_repos['url'], apt_repos['distribution'])
+    all_repo_hash = get_repo_hash(APT_BASE_URL + apt_repos['url'], apt_repos['distribution'])
 
     for repo_config in apt_repos['additional']:
-        all_repo_hash += get_repo_hash(repo_config['url'], repo_config['distribution'])
+        all_repo_hash += get_repo_hash(APT_BASE_URL + repo_config['url'], repo_config['distribution'])
 
     all_repo_hash += hashlib.sha256(get_apt_preferences().encode()).hexdigest()
 

--- a/scale_build/config.py
+++ b/scale_build/config.py
@@ -50,6 +50,7 @@ VERSION = get_env_variable('TRUENAS_VERSION', str, f'{_VERS}-{BUILD_TIME_OBJ.str
 TRUENAS_VENDOR = get_env_variable('TRUENAS_VENDOR', str)
 PRESERVE_ISO = get_env_variable('PRESERVE_ISO', bool, False)
 APT_INTERNAL_BUILD = get_env_variable('APT_INTERNAL_BUILD', bool, False)
+APT_BASE_CUSTOM = get_env_variable('APT_BASE_CUSTOM', str)
 
 
 # We will get branch overrides and identity file path overrides from here

--- a/scale_build/config.py
+++ b/scale_build/config.py
@@ -49,6 +49,7 @@ TRY_BRANCH_OVERRIDE = get_env_variable('TRY_BRANCH_OVERRIDE', str)
 VERSION = get_env_variable('TRUENAS_VERSION', str, f'{_VERS}-{BUILD_TIME_OBJ.strftime("%Y%m%d-%H%M%S")}')
 TRUENAS_VENDOR = get_env_variable('TRUENAS_VENDOR', str)
 PRESERVE_ISO = get_env_variable('PRESERVE_ISO', bool, False)
+APT_INTERNAL_BUILD = get_env_variable('APT_INTERNAL_BUILD', bool, False)
 
 
 # We will get branch overrides and identity file path overrides from here

--- a/scale_build/image/iso.py
+++ b/scale_build/image/iso.py
@@ -135,7 +135,8 @@ def make_iso_file():
             with tempfile.NamedTemporaryFile(suffix='.tar.gz') as f:
                 apt_repos = get_manifest()['apt-repos']
                 r = requests.get(
-                    f'{APT_BASE_URL}{apt_repos["url"]}dists/{apt_repos["distribution"]}/main/installer-amd64/current/images/cdrom/'
+                    f'{APT_BASE_URL}{apt_repos["url"]}dists/{apt_repos["distribution"]}'
+                    '/main/installer-amd64/current/images/cdrom/'
                     'debian-cd_info.tar.gz',
                     timeout=10,
                     stream=True,

--- a/scale_build/image/iso.py
+++ b/scale_build/image/iso.py
@@ -10,7 +10,7 @@ import json
 import requests
 
 from scale_build.exceptions import CallError
-from scale_build.utils.manifest import APT_BASE_URL get_manifest
+from scale_build.utils.manifest import APT_BASE_URL, get_manifest
 from scale_build.utils.run import run
 from scale_build.utils.paths import CD_DIR, CD_FILES_DIR, CHROOT_BASEDIR, CONF_GRUB, PKG_DIR, RELEASE_DIR, TMP_DIR
 from scale_build.config import TRUENAS_VENDOR

--- a/scale_build/image/iso.py
+++ b/scale_build/image/iso.py
@@ -10,7 +10,7 @@ import json
 import requests
 
 from scale_build.exceptions import CallError
-from scale_build.utils.manifest import apt_get_base_url, get_manifest
+from scale_build.utils.manifest import get_apt_base_url, get_manifest
 from scale_build.utils.run import run
 from scale_build.utils.paths import CD_DIR, CD_FILES_DIR, CHROOT_BASEDIR, CONF_GRUB, PKG_DIR, RELEASE_DIR, TMP_DIR
 from scale_build.config import TRUENAS_VENDOR
@@ -134,7 +134,7 @@ def make_iso_file():
         with tempfile.NamedTemporaryFile(dir=RELEASE_DIR) as efi_img:
             with tempfile.NamedTemporaryFile(suffix='.tar.gz') as f:
                 apt_repos = get_manifest()['apt-repos']
-                apt_base_url = apt_get_base_url()
+                apt_base_url = get_apt_base_url()
                 r = requests.get(
                     f'{apt_base_url}{apt_repos["url"]}dists/{apt_repos["distribution"]}'
                     '/main/installer-amd64/current/images/cdrom/'

--- a/scale_build/image/iso.py
+++ b/scale_build/image/iso.py
@@ -10,7 +10,7 @@ import json
 import requests
 
 from scale_build.exceptions import CallError
-from scale_build.utils.manifest import APT_BASE_URL, get_manifest
+from scale_build.utils.manifest import apt_get_base_url, get_manifest
 from scale_build.utils.run import run
 from scale_build.utils.paths import CD_DIR, CD_FILES_DIR, CHROOT_BASEDIR, CONF_GRUB, PKG_DIR, RELEASE_DIR, TMP_DIR
 from scale_build.config import TRUENAS_VENDOR
@@ -134,8 +134,9 @@ def make_iso_file():
         with tempfile.NamedTemporaryFile(dir=RELEASE_DIR) as efi_img:
             with tempfile.NamedTemporaryFile(suffix='.tar.gz') as f:
                 apt_repos = get_manifest()['apt-repos']
+                apt_base_url = apt_get_base_url()
                 r = requests.get(
-                    f'{APT_BASE_URL}{apt_repos["url"]}dists/{apt_repos["distribution"]}'
+                    f'{apt_base_url}{apt_repos["url"]}dists/{apt_repos["distribution"]}'
                     '/main/installer-amd64/current/images/cdrom/'
                     'debian-cd_info.tar.gz',
                     timeout=10,

--- a/scale_build/image/iso.py
+++ b/scale_build/image/iso.py
@@ -10,7 +10,7 @@ import json
 import requests
 
 from scale_build.exceptions import CallError
-from scale_build.utils.manifest import get_manifest
+from scale_build.utils.manifest import APT_BASE_URL get_manifest
 from scale_build.utils.run import run
 from scale_build.utils.paths import CD_DIR, CD_FILES_DIR, CHROOT_BASEDIR, CONF_GRUB, PKG_DIR, RELEASE_DIR, TMP_DIR
 from scale_build.config import TRUENAS_VENDOR
@@ -135,7 +135,7 @@ def make_iso_file():
             with tempfile.NamedTemporaryFile(suffix='.tar.gz') as f:
                 apt_repos = get_manifest()['apt-repos']
                 r = requests.get(
-                    f'{apt_repos["url"]}dists/{apt_repos["distribution"]}/main/installer-amd64/current/images/cdrom/'
+                    f'{APT_BASE_URL}{apt_repos["url"]}dists/{apt_repos["distribution"]}/main/installer-amd64/current/images/cdrom/'
                     'debian-cd_info.tar.gz',
                     timeout=10,
                     stream=True,

--- a/scale_build/image/update.py
+++ b/scale_build/image/update.py
@@ -7,7 +7,7 @@ import shutil
 import stat
 
 from scale_build.config import SIGNING_KEY, SIGNING_PASSWORD
-from scale_build.utils.manifest import APT_BASE_URL, get_manifest
+from scale_build.utils.manifest import apt_get_base_url, get_manifest
 from scale_build.utils.run import run
 from scale_build.utils.paths import CHROOT_BASEDIR, RELEASE_DIR, UPDATE_DIR
 
@@ -110,9 +110,10 @@ def install_rootfs_packages_impl():
 
 def get_apt_sources():
     apt_repos = get_manifest()['apt-repos']
-    apt_sources = [f'deb {APT_BASE_URL}{apt_repos["url"]} {apt_repos["distribution"]} {apt_repos["components"]}']
+    apt_base_url = apt_get_base_url()
+    apt_sources = [f'deb {apt_base_url}{apt_repos["url"]} {apt_repos["distribution"]} {apt_repos["components"]}']
     for repo in apt_repos['additional']:
-        apt_sources.append(f'deb {APT_BASE_URL}{repo["url"]} {repo["distribution"]} {repo["component"]}')
+        apt_sources.append(f'deb {apt_base_url}{repo["url"]} {repo["distribution"]} {repo["component"]}')
 
     return apt_sources
 

--- a/scale_build/image/update.py
+++ b/scale_build/image/update.py
@@ -7,7 +7,7 @@ import shutil
 import stat
 
 from scale_build.config import SIGNING_KEY, SIGNING_PASSWORD
-from scale_build.utils.manifest import APT_BASE_URL get_manifest
+from scale_build.utils.manifest import APT_BASE_URL, get_manifest
 from scale_build.utils.run import run
 from scale_build.utils.paths import CHROOT_BASEDIR, RELEASE_DIR, UPDATE_DIR
 

--- a/scale_build/image/update.py
+++ b/scale_build/image/update.py
@@ -7,7 +7,7 @@ import shutil
 import stat
 
 from scale_build.config import SIGNING_KEY, SIGNING_PASSWORD
-from scale_build.utils.manifest import get_manifest
+from scale_build.utils.manifest import APT_BASE_URL get_manifest
 from scale_build.utils.run import run
 from scale_build.utils.paths import CHROOT_BASEDIR, RELEASE_DIR, UPDATE_DIR
 
@@ -110,9 +110,10 @@ def install_rootfs_packages_impl():
 
 def get_apt_sources():
     apt_repos = get_manifest()['apt-repos']
-    apt_sources = [f'deb {apt_repos["url"]} {apt_repos["distribution"]} {apt_repos["components"]}']
+    apt_sources = [f'deb {APT_BASE_URL}{apt_repos["url"]} {apt_repos["distribution"]} {apt_repos["components"]}']
     for repo in apt_repos['additional']:
-        apt_sources.append(f'deb {repo["url"]} {repo["distribution"]} {repo["component"]}')
+        apt_sources.append(f'deb {APT_BASE_URL}{repo["url"]} {repo["distribution"]} {repo["component"]}')
+
     return apt_sources
 
 

--- a/scale_build/image/update.py
+++ b/scale_build/image/update.py
@@ -7,7 +7,7 @@ import shutil
 import stat
 
 from scale_build.config import SIGNING_KEY, SIGNING_PASSWORD
-from scale_build.utils.manifest import apt_get_base_url, get_manifest
+from scale_build.utils.manifest import get_apt_base_url, get_manifest
 from scale_build.utils.run import run
 from scale_build.utils.paths import CHROOT_BASEDIR, RELEASE_DIR, UPDATE_DIR
 
@@ -110,7 +110,7 @@ def install_rootfs_packages_impl():
 
 def get_apt_sources():
     apt_repos = get_manifest()['apt-repos']
-    apt_base_url = apt_get_base_url()
+    apt_base_url = get_apt_base_url()
     apt_sources = [f'deb {apt_base_url}{apt_repos["url"]} {apt_repos["distribution"]} {apt_repos["components"]}']
     for repo in apt_repos['additional']:
         apt_sources.append(f'deb {apt_base_url}{repo["url"]} {repo["distribution"]} {repo["component"]}')

--- a/scale_build/utils/manifest.py
+++ b/scale_build/utils/manifest.py
@@ -5,7 +5,7 @@ import yaml
 
 from urllib.parse import urlparse
 
-from scale_build.config import APT_INTERNAL_BUILD, SKIP_SOURCE_REPO_VALIDATION, TRAIN
+from scale_build.config import APT_BASE_CUSTOM, APT_INTERNAL_BUILD, SKIP_SOURCE_REPO_VALIDATION, TRAIN
 from scale_build.exceptions import CallError, MissingManifest
 from scale_build.utils.paths import MANIFEST
 
@@ -258,9 +258,15 @@ def validate_manifest():
 
 def get_apt_base_url():
     apt_repos = get_manifest()['apt-repos']
-    APT_BASE_URL = ""
+    apt_base_url = ""
+
+    # If the user provided their own location
+    if APT_BASE_CUSTOM:
+        return APT_BASE_CUSTOM
+
+    # Return either the CDN or the internal build url
     if APT_INTERNAL_BUILD:
-        APT_BASE_URL = f'{apt_repos["base-url-internal"]}'
+        apt_base_url = f'{apt_repos["base-url-internal"]}'
     else:
-        APT_BASE_URL = f'{apt_repos["base-url"]}'
-    return APT_BASE_URL
+        apt_base_url = f'{apt_repos["base-url"]}'
+    return apt_base_url

--- a/scale_build/utils/manifest.py
+++ b/scale_build/utils/manifest.py
@@ -256,10 +256,11 @@ def validate_manifest():
         )
 
 
-# Check and set the base APT url
-apt_repos = get_manifest()['apt-repos']
-APT_BASE_URL = ""
-if APT_INTERNAL_BUILD:
-    APT_BASE_URL = f'{apt_repos["base-url-internal"]}'
-else:
-    APT_BASE_URL = f'{apt_repos["base-url"]}'
+def get_apt_base_url():
+    apt_repos = get_manifest()['apt-repos']
+    APT_BASE_URL = ""
+    if APT_INTERNAL_BUILD:
+        APT_BASE_URL = f'{apt_repos["base-url-internal"]}'
+    else:
+        APT_BASE_URL = f'{apt_repos["base-url"]}'
+    return APT_BASE_URL

--- a/scale_build/utils/manifest.py
+++ b/scale_build/utils/manifest.py
@@ -260,6 +260,6 @@ def validate_manifest():
 apt_repos = get_manifest()['apt-repos']
 APT_BASE_URL = ""
 if APT_INTERNAL_BUILD:
-    APT_BASE_URL = f"{apt_repos['base-url-internal']}"
+    APT_BASE_URL = f'{apt_repos["base-url-internal"]}'
 else:
-    APT_BASE_URL = f"{apt_repos['base-url']}"
+    APT_BASE_URL = f'{apt_repos["base-url"]}'

--- a/scale_build/utils/manifest.py
+++ b/scale_build/utils/manifest.py
@@ -260,6 +260,6 @@ def validate_manifest():
 apt_repos = get_manifest()['apt-repos']
 APT_BASE_URL = ""
 if APT_INTERNAL_BUILD:
-    APT_BASE_URL = "{apt_repos['base-url-internal']}"
+    APT_BASE_URL = f"{apt_repos['base-url-internal']}"
 else:
-    APT_BASE_URL = "{apt_repos['base-url']}"
+    APT_BASE_URL = f"{apt_repos['base-url']}"

--- a/scale_build/utils/manifest.py
+++ b/scale_build/utils/manifest.py
@@ -5,7 +5,7 @@ import yaml
 
 from urllib.parse import urlparse
 
-from scale_build.config import SKIP_SOURCE_REPO_VALIDATION, TRAIN
+from scale_build.config import APT_INTERNAL_BUILD, SKIP_SOURCE_REPO_VALIDATION, TRAIN
 from scale_build.exceptions import CallError, MissingManifest
 from scale_build.utils.paths import MANIFEST
 
@@ -77,6 +77,8 @@ MANIFEST_SCHEMA = {
         'code_name': {'type': 'string'},
         'debian_release': {'type': 'string'},
         'identity_file_path_default': {'type': 'string'},
+        'base-url': {'type': 'string'},
+        'base-url-internal': {'type': 'string'},
         'apt-repos': {
             'type': 'object',
             'properties': {
@@ -252,3 +254,12 @@ def validate_manifest():
             'accepts packages from github.com/truenas organization (To skip this for dev '
             'purposes, please set "SKIP_SOURCE_REPO_VALIDATION" in your environment).'
         )
+
+
+# Check and set the base APT url
+apt_repos = get_manifest()['apt-repos']
+APT_BASE_URL = ""
+if APT_INTERNAL_BUILD:
+    APT_BASE_URL = "{apt_repos['base-url-internal']}"
+else:
+    APT_BASE_URL = "{apt_repos['base-url']}"


### PR DESCRIPTION
Added an option to set APT_INTERNAL_BUILD in the environment, which will toggle the builder to use the CDN Apt, or the iX Internal Apt Repo. 

Additionally, the environment variable APT_BASE_CUSTOM can be set to a URL if you wish to override both options to pull from another location at build time. 