### PR TITLE
NAS-132446 / 24.10.1 / Initial add of option to use internal APT repo for builds (by kmoore134)

### DIFF
--- a/conf/build.manifest
+++ b/conf/build.manifest
@@ -8,23 +8,25 @@ identity_file_path_default: "~/.ssh/id_rsa"
 # into the build chroots, or the final system images.
 ############################################################################
 apt-repos:
-  url: https://apt.sys.truenas.net/electriceel/nightlies/debian/
+  base-url: https://apt.sys.truenas.net
+  base-url-internal: http://apt-mirror.tn.ixsystems.net
+  url: /electriceel/nightlies/debian/
   distribution: bookworm
   components: main
   additional:
-  - url: https://apt.sys.truenas.net/electriceel/nightlies/debian-security/
+  - url: /electriceel/nightlies/debian-security/
     distribution: bookworm-security
     component: main
-  - url: https://apt.sys.truenas.net/electriceel/nightlies/debian-backports/
+  - url: /electriceel/nightlies/debian-backports/
     distribution: bookworm-backports
     component: "main contrib non-free non-free-firmware"
-  - url: https://apt.sys.truenas.net/electriceel/nightlies/debian-debug/
+  - url: /electriceel/nightlies/debian-debug/
     distribution: bookworm-debug
     component: main
-  - url: https://apt.sys.truenas.net/electriceel/nightlies/yarn/
+  - url: /electriceel/nightlies/yarn/
     distribution: stable
     component: main
-  - url: https://apt.sys.truenas.net/electriceel/nightlies/docker/
+  - url: /electriceel/nightlies/docker/
     distribution: bookworm
     component: stable
     key: keys/docker.gpg

--- a/scale_build/bootstrap/bootstrapdir.py
+++ b/scale_build/bootstrap/bootstrapdir.py
@@ -3,7 +3,7 @@ import os
 import shutil
 
 from scale_build.clean import clean_packages
-from scale_build.utils.manifest import get_manifest
+from scale_build.utils.manifest import get_apt_base_url, get_manifest
 from scale_build.utils.paths import BUILDER_DIR, CHROOT_BASEDIR, REFERENCE_FILES, REFERENCE_FILES_DIR
 from scale_build.utils.run import run
 
@@ -30,11 +30,12 @@ class BootstrapDir(CacheMixin, HashMixin):
 
     def debootstrap_debian(self):
         manifest = get_manifest()
+        apt_base_url = get_apt_base_url()
         run(
             ['debootstrap'] + self.deopts + [
                 '--keyring', '/etc/apt/trusted.gpg.d/debian-archive-truenas-automatic.gpg',
                 manifest['debian_release'],
-                self.chroot_basedir, manifest['apt-repos']['url']
+                self.chroot_basedir, apt_base_url + manifest['apt-repos']['url']
             ]
         )
 
@@ -46,6 +47,7 @@ class BootstrapDir(CacheMixin, HashMixin):
 
         self.add_trusted_apt_key()
         apt_repos = get_manifest()['apt-repos']
+        apt_base_url = get_apt_base_url()
         self.debootstrap_debian()
         self.setup_mounts()
 
@@ -61,7 +63,7 @@ class BootstrapDir(CacheMixin, HashMixin):
         run(['chroot', self.chroot_basedir, 'apt', 'install', '-y', 'gnupg'])
 
         # Save the correct repo in sources.list
-        apt_sources = [f'deb {apt_repos["url"]} {apt_repos["distribution"]} {apt_repos["components"]}']
+        apt_sources = [f'deb {apt_base_url}{apt_repos["url"]} {apt_repos["distribution"]} {apt_repos["components"]}']
 
         # Add additional repos
         for repo in apt_repos['additional']:
@@ -71,7 +73,7 @@ class BootstrapDir(CacheMixin, HashMixin):
                 run(['chroot', self.chroot_basedir, 'apt-key', 'add', '/apt.key'])
                 os.unlink(os.path.join(self.chroot_basedir, 'apt.key'))
 
-            apt_sources.append(f'deb {repo["url"]} {repo["distribution"]} {repo["component"]}')
+            apt_sources.append(f'deb {apt_base_url}{repo["url"]} {repo["distribution"]} {repo["component"]}')
 
         with open(apt_sources_path, 'w') as f:
             f.write('\n'.join(apt_sources))
@@ -147,11 +149,12 @@ class RootfsBootstrapDir(BootstrapDir):
 
     def debootstrap_debian(self):
         manifest = get_manifest()
+        apt_base_url = get_apt_base_url()
         run(
             ['debootstrap'] + self.deopts + [
                 '--foreign', '--keyring', '/etc/apt/trusted.gpg.d/debian-archive-truenas-automatic.gpg',
                 manifest['debian_release'],
-                self.chroot_basedir, manifest['apt-repos']['url']
+                self.chroot_basedir, apt_base_url + manifest['apt-repos']['url']
             ]
         )
         for reference_file in REFERENCE_FILES:

--- a/scale_build/bootstrap/hash.py
+++ b/scale_build/bootstrap/hash.py
@@ -6,7 +6,7 @@ import re
 import requests
 import urllib.parse
 
-from scale_build.utils.manifest import get_manifest
+from scale_build.utils.manifest import get_apt_base_url, get_manifest
 from scale_build.utils.run import run
 from scale_build.utils.paths import CACHE_DIR, HASH_DIR
 
@@ -27,11 +27,12 @@ def get_repo_hash(repo_url, distribution):
 
 def get_all_repo_hash():
     apt_repos = get_manifest()['apt-repos']
+    apt_base_url = get_apt_base_url()
     # Start by validating the main APT repo
-    all_repo_hash = get_repo_hash(apt_repos['url'], apt_repos['distribution'])
+    all_repo_hash = get_repo_hash(apt_base_url + apt_repos['url'], apt_repos['distribution'])
 
     for repo_config in apt_repos['additional']:
-        all_repo_hash += get_repo_hash(repo_config['url'], repo_config['distribution'])
+        all_repo_hash += get_repo_hash(apt_base_url + repo_config['url'], repo_config['distribution'])
 
     all_repo_hash += hashlib.sha256(get_apt_preferences().encode()).hexdigest()
 

--- a/scale_build/config.py
+++ b/scale_build/config.py
@@ -49,6 +49,8 @@ TRY_BRANCH_OVERRIDE = get_env_variable('TRY_BRANCH_OVERRIDE', str)
 VERSION = get_env_variable('TRUENAS_VERSION', str, f'{_VERS}-{BUILD_TIME_OBJ.strftime("%Y%m%d-%H%M%S")}')
 TRUENAS_VENDOR = get_env_variable('TRUENAS_VENDOR', str)
 PRESERVE_ISO = get_env_variable('PRESERVE_ISO', bool, False)
+APT_INTERNAL_BUILD = get_env_variable('APT_INTERNAL_BUILD', bool, False)
+APT_BASE_CUSTOM = get_env_variable('APT_BASE_CUSTOM', str)
 
 
 # We will get branch overrides and identity file path overrides from here

--- a/scale_build/image/iso.py
+++ b/scale_build/image/iso.py
@@ -10,7 +10,7 @@ import json
 import requests
 
 from scale_build.exceptions import CallError
-from scale_build.utils.manifest import get_manifest
+from scale_build.utils.manifest import get_apt_base_url, get_manifest
 from scale_build.utils.run import run
 from scale_build.utils.paths import CD_DIR, CD_FILES_DIR, CHROOT_BASEDIR, CONF_GRUB, PKG_DIR, RELEASE_DIR, TMP_DIR
 from scale_build.config import TRUENAS_VENDOR
@@ -134,8 +134,10 @@ def make_iso_file():
         with tempfile.NamedTemporaryFile(dir=RELEASE_DIR) as efi_img:
             with tempfile.NamedTemporaryFile(suffix='.tar.gz') as f:
                 apt_repos = get_manifest()['apt-repos']
+                apt_base_url = get_apt_base_url()
                 r = requests.get(
-                    f'{apt_repos["url"]}dists/{apt_repos["distribution"]}/main/installer-amd64/current/images/cdrom/'
+                    f'{apt_base_url}{apt_repos["url"]}dists/{apt_repos["distribution"]}'
+                    '/main/installer-amd64/current/images/cdrom/'
                     'debian-cd_info.tar.gz',
                     timeout=10,
                     stream=True,

--- a/scale_build/image/update.py
+++ b/scale_build/image/update.py
@@ -7,7 +7,7 @@ import shutil
 import stat
 
 from scale_build.config import SIGNING_KEY, SIGNING_PASSWORD
-from scale_build.utils.manifest import get_manifest
+from scale_build.utils.manifest import get_apt_base_url, get_manifest
 from scale_build.utils.run import run
 from scale_build.utils.paths import CHROOT_BASEDIR, RELEASE_DIR, UPDATE_DIR
 
@@ -110,9 +110,11 @@ def install_rootfs_packages_impl():
 
 def get_apt_sources():
     apt_repos = get_manifest()['apt-repos']
-    apt_sources = [f'deb {apt_repos["url"]} {apt_repos["distribution"]} {apt_repos["components"]}']
+    apt_base_url = get_apt_base_url()
+    apt_sources = [f'deb {apt_base_url}{apt_repos["url"]} {apt_repos["distribution"]} {apt_repos["components"]}']
     for repo in apt_repos['additional']:
-        apt_sources.append(f'deb {repo["url"]} {repo["distribution"]} {repo["component"]}')
+        apt_sources.append(f'deb {apt_base_url}{repo["url"]} {repo["distribution"]} {repo["component"]}')
+
     return apt_sources
 
 

--- a/scale_build/utils/manifest.py
+++ b/scale_build/utils/manifest.py
@@ -5,7 +5,7 @@ import yaml
 
 from urllib.parse import urlparse
 
-from scale_build.config import SKIP_SOURCE_REPO_VALIDATION, TRAIN
+from scale_build.config import APT_BASE_CUSTOM, APT_INTERNAL_BUILD, SKIP_SOURCE_REPO_VALIDATION, TRAIN
 from scale_build.exceptions import CallError, MissingManifest
 from scale_build.utils.paths import MANIFEST
 
@@ -77,6 +77,8 @@ MANIFEST_SCHEMA = {
         'code_name': {'type': 'string'},
         'debian_release': {'type': 'string'},
         'identity_file_path_default': {'type': 'string'},
+        'base-url': {'type': 'string'},
+        'base-url-internal': {'type': 'string'},
         'apt-repos': {
             'type': 'object',
             'properties': {
@@ -252,3 +254,19 @@ def validate_manifest():
             'accepts packages from github.com/truenas organization (To skip this for dev '
             'purposes, please set "SKIP_SOURCE_REPO_VALIDATION" in your environment).'
         )
+
+
+def get_apt_base_url():
+    apt_repos = get_manifest()['apt-repos']
+    apt_base_url = ""
+
+    # If the user provided their own location
+    if APT_BASE_CUSTOM:
+        return APT_BASE_CUSTOM
+
+    # Return either the CDN or the internal build url
+    if APT_INTERNAL_BUILD:
+        apt_base_url = f'{apt_repos["base-url-internal"]}'
+    else:
+        apt_base_url = f'{apt_repos["base-url"]}'
+    return apt_base_url


### PR DESCRIPTION
Added an option to set APT_INTERNAL_BUILD in the environment, which will toggle the builder to use the CDN Apt, or the iX Internal Apt Repo. 

Additionally, the environment variable APT_BASE_CUSTOM can be set to a URL if you wish to override both options to pull from another location at build time. 

Original PR: https://github.com/truenas/scale-build/pull/754
Jira URL: https://ixsystems.atlassian.net/browse/NAS-132446