### PR TITLE
NAS-132554 / 24.10.1 / Revert NAS-132446 (by yocalebo)

### DIFF
--- a/conf/build.manifest
+++ b/conf/build.manifest
@@ -8,25 +8,23 @@ identity_file_path_default: "~/.ssh/id_rsa"
 # into the build chroots, or the final system images.
 ############################################################################
 apt-repos:
-  base-url: https://apt.sys.truenas.net
-  base-url-internal: http://apt-mirror.tn.ixsystems.net
-  url: /electriceel/nightlies/debian/
+  url: https://apt.sys.truenas.net/electriceel/nightlies/debian/
   distribution: bookworm
   components: main
   additional:
-  - url: /electriceel/nightlies/debian-security/
+  - url: https://apt.sys.truenas.net/electriceel/nightlies/debian-security/
     distribution: bookworm-security
     component: main
-  - url: /electriceel/nightlies/debian-backports/
+  - url: https://apt.sys.truenas.net/electriceel/nightlies/debian-backports/
     distribution: bookworm-backports
     component: "main contrib non-free non-free-firmware"
-  - url: /electriceel/nightlies/debian-debug/
+  - url: https://apt.sys.truenas.net/electriceel/nightlies/debian-debug/
     distribution: bookworm-debug
     component: main
-  - url: /electriceel/nightlies/yarn/
+  - url: https://apt.sys.truenas.net/electriceel/nightlies/yarn/
     distribution: stable
     component: main
-  - url: /electriceel/nightlies/docker/
+  - url: https://apt.sys.truenas.net/electriceel/nightlies/docker/
     distribution: bookworm
     component: stable
     key: keys/docker.gpg

--- a/scale_build/bootstrap/hash.py
+++ b/scale_build/bootstrap/hash.py
@@ -6,7 +6,7 @@ import re
 import requests
 import urllib.parse
 
-from scale_build.utils.manifest import get_apt_base_url, get_manifest
+from scale_build.utils.manifest import get_manifest
 from scale_build.utils.run import run
 from scale_build.utils.paths import CACHE_DIR, HASH_DIR
 
@@ -27,12 +27,11 @@ def get_repo_hash(repo_url, distribution):
 
 def get_all_repo_hash():
     apt_repos = get_manifest()['apt-repos']
-    apt_base_url = get_apt_base_url()
     # Start by validating the main APT repo
-    all_repo_hash = get_repo_hash(apt_base_url + apt_repos['url'], apt_repos['distribution'])
+    all_repo_hash = get_repo_hash(apt_repos['url'], apt_repos['distribution'])
 
     for repo_config in apt_repos['additional']:
-        all_repo_hash += get_repo_hash(apt_base_url + repo_config['url'], repo_config['distribution'])
+        all_repo_hash += get_repo_hash(repo_config['url'], repo_config['distribution'])
 
     all_repo_hash += hashlib.sha256(get_apt_preferences().encode()).hexdigest()
 

--- a/scale_build/config.py
+++ b/scale_build/config.py
@@ -49,8 +49,6 @@ TRY_BRANCH_OVERRIDE = get_env_variable('TRY_BRANCH_OVERRIDE', str)
 VERSION = get_env_variable('TRUENAS_VERSION', str, f'{_VERS}-{BUILD_TIME_OBJ.strftime("%Y%m%d-%H%M%S")}')
 TRUENAS_VENDOR = get_env_variable('TRUENAS_VENDOR', str)
 PRESERVE_ISO = get_env_variable('PRESERVE_ISO', bool, False)
-APT_INTERNAL_BUILD = get_env_variable('APT_INTERNAL_BUILD', bool, False)
-APT_BASE_CUSTOM = get_env_variable('APT_BASE_CUSTOM', str)
 
 
 # We will get branch overrides and identity file path overrides from here

--- a/scale_build/image/iso.py
+++ b/scale_build/image/iso.py
@@ -10,7 +10,7 @@ import json
 import requests
 
 from scale_build.exceptions import CallError
-from scale_build.utils.manifest import get_apt_base_url, get_manifest
+from scale_build.utils.manifest import get_manifest
 from scale_build.utils.run import run
 from scale_build.utils.paths import CD_DIR, CD_FILES_DIR, CHROOT_BASEDIR, CONF_GRUB, PKG_DIR, RELEASE_DIR, TMP_DIR
 from scale_build.config import TRUENAS_VENDOR
@@ -134,10 +134,8 @@ def make_iso_file():
         with tempfile.NamedTemporaryFile(dir=RELEASE_DIR) as efi_img:
             with tempfile.NamedTemporaryFile(suffix='.tar.gz') as f:
                 apt_repos = get_manifest()['apt-repos']
-                apt_base_url = get_apt_base_url()
                 r = requests.get(
-                    f'{apt_base_url}{apt_repos["url"]}dists/{apt_repos["distribution"]}'
-                    '/main/installer-amd64/current/images/cdrom/'
+                    f'{apt_repos["url"]}dists/{apt_repos["distribution"]}/main/installer-amd64/current/images/cdrom/'
                     'debian-cd_info.tar.gz',
                     timeout=10,
                     stream=True,

--- a/scale_build/image/update.py
+++ b/scale_build/image/update.py
@@ -7,7 +7,7 @@ import shutil
 import stat
 
 from scale_build.config import SIGNING_KEY, SIGNING_PASSWORD
-from scale_build.utils.manifest import get_apt_base_url, get_manifest
+from scale_build.utils.manifest import get_manifest
 from scale_build.utils.run import run
 from scale_build.utils.paths import CHROOT_BASEDIR, RELEASE_DIR, UPDATE_DIR
 
@@ -110,11 +110,9 @@ def install_rootfs_packages_impl():
 
 def get_apt_sources():
     apt_repos = get_manifest()['apt-repos']
-    apt_base_url = get_apt_base_url()
-    apt_sources = [f'deb {apt_base_url}{apt_repos["url"]} {apt_repos["distribution"]} {apt_repos["components"]}']
+    apt_sources = [f'deb {apt_repos["url"]} {apt_repos["distribution"]} {apt_repos["components"]}']
     for repo in apt_repos['additional']:
-        apt_sources.append(f'deb {apt_base_url}{repo["url"]} {repo["distribution"]} {repo["component"]}')
-
+        apt_sources.append(f'deb {repo["url"]} {repo["distribution"]} {repo["component"]}')
     return apt_sources
 
 

--- a/scale_build/utils/manifest.py
+++ b/scale_build/utils/manifest.py
@@ -5,7 +5,7 @@ import yaml
 
 from urllib.parse import urlparse
 
-from scale_build.config import APT_BASE_CUSTOM, APT_INTERNAL_BUILD, SKIP_SOURCE_REPO_VALIDATION, TRAIN
+from scale_build.config import SKIP_SOURCE_REPO_VALIDATION, TRAIN
 from scale_build.exceptions import CallError, MissingManifest
 from scale_build.utils.paths import MANIFEST
 
@@ -77,8 +77,6 @@ MANIFEST_SCHEMA = {
         'code_name': {'type': 'string'},
         'debian_release': {'type': 'string'},
         'identity_file_path_default': {'type': 'string'},
-        'base-url': {'type': 'string'},
-        'base-url-internal': {'type': 'string'},
         'apt-repos': {
             'type': 'object',
             'properties': {
@@ -254,19 +252,3 @@ def validate_manifest():
             'accepts packages from github.com/truenas organization (To skip this for dev '
             'purposes, please set "SKIP_SOURCE_REPO_VALIDATION" in your environment).'
         )
-
-
-def get_apt_base_url():
-    apt_repos = get_manifest()['apt-repos']
-    apt_base_url = ""
-
-    # If the user provided their own location
-    if APT_BASE_CUSTOM:
-        return APT_BASE_CUSTOM
-
-    # Return either the CDN or the internal build url
-    if APT_INTERNAL_BUILD:
-        apt_base_url = f'{apt_repos["base-url-internal"]}'
-    else:
-        apt_base_url = f'{apt_repos["base-url"]}'
-    return apt_base_url


### PR DESCRIPTION
This works well enough to produce broken images. It also doesn't consider local build directory caches. We'll add this functionality in a subsequent PR but need to remove this so we don't start generating images with these ENV settings.

This reverts commit 5f95982024caf849323997cd47a257726a272838.

Original PR: https://github.com/truenas/scale-build/pull/759
Jira URL: https://ixsystems.atlassian.net/browse/NAS-132554