### PR TITLE
NAS-132571 / 25.04 / Internal apt mirror support

### DIFF
--- a/conf/build.manifest
+++ b/conf/build.manifest
@@ -8,23 +8,25 @@ identity_file_path_default: "~/.ssh/id_rsa"
 # into the build chroots, or the final system images.
 ############################################################################
 apt-repos:
-  url: https://apt.sys.truenas.net/fangtooth/nightlies/debian/
+  base-url: https://apt.sys.truenas.net/
+  base-url-internal: http://apt-mirror.tn.ixsystems.net/
+  url: fangtooth/nightlies/debian/
   distribution: bookworm
   components: main
   additional:
-  - url: https://apt.sys.truenas.net/fangtooth/nightlies/debian-security/
+  - url: fangtooth/nightlies/debian-security/
     distribution: bookworm-security
     component: main
-  - url: https://apt.sys.truenas.net/fangtooth/nightlies/debian-backports/
+  - url: fangtooth/nightlies/debian-backports/
     distribution: bookworm-backports
     component: "main contrib non-free non-free-firmware"
-  - url: https://apt.sys.truenas.net/fangtooth/nightlies/debian-debug/
+  - url: fangtooth/nightlies/debian-debug/
     distribution: bookworm-debug
     component: main
-  - url: https://apt.sys.truenas.net/fangtooth/nightlies/yarn/
+  - url: fangtooth/nightlies/yarn/
     distribution: stable
     component: main
-  - url: https://apt.sys.truenas.net/fangtooth/nightlies/docker/
+  - url: fangtooth/nightlies/docker/
     distribution: bookworm
     component: stable
     key: keys/docker.gpg

--- a/scale_build/bootstrap/bootstrapdir.py
+++ b/scale_build/bootstrap/bootstrapdir.py
@@ -3,7 +3,7 @@ import os
 import shutil
 
 from scale_build.clean import clean_packages
-from scale_build.utils.manifest import get_manifest
+from scale_build.utils.manifest import get_manifest, get_apt_repos
 from scale_build.utils.paths import BUILDER_DIR, CHROOT_BASEDIR, REFERENCE_FILES, REFERENCE_FILES_DIR
 from scale_build.utils.run import run
 
@@ -34,7 +34,7 @@ class BootstrapDir(CacheMixin, HashMixin):
             ['debootstrap'] + self.deopts + [
                 '--keyring', '/etc/apt/trusted.gpg.d/debian-archive-truenas-automatic.gpg',
                 manifest['debian_release'],
-                self.chroot_basedir, manifest['apt-repos']['url']
+                self.chroot_basedir, get_apt_repos(check_custom=True)['url']
             ]
         )
 
@@ -45,7 +45,7 @@ class BootstrapDir(CacheMixin, HashMixin):
             return
 
         self.add_trusted_apt_key()
-        apt_repos = get_manifest()['apt-repos']
+        apt_repos = get_apt_repos(check_custom=True)
         self.debootstrap_debian()
         self.setup_mounts()
 
@@ -151,7 +151,7 @@ class RootfsBootstrapDir(BootstrapDir):
             ['debootstrap'] + self.deopts + [
                 '--foreign', '--keyring', '/etc/apt/trusted.gpg.d/debian-archive-truenas-automatic.gpg',
                 manifest['debian_release'],
-                self.chroot_basedir, manifest['apt-repos']['url']
+                self.chroot_basedir, get_apt_repos(check_custom=True)['url']
             ]
         )
         for reference_file in REFERENCE_FILES:

--- a/scale_build/bootstrap/hash.py
+++ b/scale_build/bootstrap/hash.py
@@ -6,7 +6,7 @@ import re
 import requests
 import urllib.parse
 
-from scale_build.utils.manifest import get_manifest
+from scale_build.utils.manifest import get_apt_repos
 from scale_build.utils.run import run
 from scale_build.utils.paths import CACHE_DIR, HASH_DIR
 
@@ -26,7 +26,7 @@ def get_repo_hash(repo_url: str, distribution: str) -> str:
 
 
 def get_all_repo_hash():
-    apt_repos = get_manifest()['apt-repos']
+    apt_repos = get_apt_repos(check_custom=True)
     # Start by validating the main APT repo
     all_repo_hash = get_repo_hash(apt_repos['url'], apt_repos['distribution'])
 

--- a/scale_build/bootstrap/hash.py
+++ b/scale_build/bootstrap/hash.py
@@ -19,10 +19,10 @@ logging.getLogger('urllib3').setLevel(logging.INFO)
 INSTALLED_PACKAGES_REGEX = re.compile(r'([^\t]+)\t([^\t]+)\t([\S]+)\n')
 
 
-def get_repo_hash(repo_url, distribution):
+def get_repo_hash(repo_url: str, distribution: str) -> str:
     resp = requests.get(urllib.parse.urljoin(repo_url, os.path.join('dists', distribution, 'Release')), timeout=60)
     resp.raise_for_status()
-    return hashlib.sha256(resp.content).hexdigest()
+    return hashlib.sha256(resp.content + repo_url.encode()).hexdigest()
 
 
 def get_all_repo_hash():

--- a/scale_build/config.py
+++ b/scale_build/config.py
@@ -29,6 +29,8 @@ def get_normalized_value(value, _type, default_value=None):
         return _type(default_value) if default_value else _type()
 
 
+APT_BASE_CUSTOM = get_env_variable('APT_BASE_CUSTOM', str)
+APT_INTERNAL_BUILD = get_env_variable('APT_INTERNAL_BUILD', bool, False)
 BUILD_TIME = int(time())
 BUILD_TIME_OBJ = datetime.fromtimestamp(BUILD_TIME)
 BUILDER_DIR = get_env_variable('BUILDER_DIR', str, './')

--- a/scale_build/image/iso.py
+++ b/scale_build/image/iso.py
@@ -10,7 +10,7 @@ import json
 import requests
 
 from scale_build.exceptions import CallError
-from scale_build.utils.manifest import get_manifest
+from scale_build.utils.manifest import get_apt_repos, get_manifest
 from scale_build.utils.run import run
 from scale_build.utils.paths import CD_DIR, CD_FILES_DIR, CHROOT_BASEDIR, CONF_GRUB, PKG_DIR, RELEASE_DIR, TMP_DIR
 from scale_build.config import TRUENAS_VENDOR
@@ -133,7 +133,7 @@ def make_iso_file():
         # Let's use pre-built Debian GRUB EFI image that the official Debian ISO installer uses.
         with tempfile.NamedTemporaryFile(dir=RELEASE_DIR) as efi_img:
             with tempfile.NamedTemporaryFile(suffix='.tar.gz') as f:
-                apt_repos = get_manifest()['apt-repos']
+                apt_repos = get_apt_repos(check_custom=True)
                 r = requests.get(
                     f'{apt_repos["url"]}dists/{apt_repos["distribution"]}/main/installer-amd64/current/images/cdrom/'
                     'debian-cd_info.tar.gz',
@@ -152,8 +152,9 @@ def make_iso_file():
             run_in_chroot([
                 'grub-mkrescue',
                 '-o', iso,
-                '--efi-boot-part', os.path.join(RELEASE_DIR,
-                                                os.path.relpath(efi_img.name, os.path.abspath(RELEASE_DIR))),
+                '--efi-boot-part', os.path.join(
+                    RELEASE_DIR, os.path.relpath(efi_img.name, os.path.abspath(RELEASE_DIR))
+                ),
                 CD_DIR,
             ])
 

--- a/scale_build/image/update.py
+++ b/scale_build/image/update.py
@@ -8,7 +8,7 @@ import stat
 import tempfile
 
 from scale_build.config import SIGNING_KEY, SIGNING_PASSWORD
-from scale_build.utils.manifest import get_manifest
+from scale_build.utils.manifest import get_manifest, get_apt_repos
 from scale_build.utils.run import run
 from scale_build.utils.paths import CHROOT_BASEDIR, RELEASE_DIR, UPDATE_DIR
 
@@ -110,7 +110,8 @@ def install_rootfs_packages_impl():
 
 
 def get_apt_sources():
-    apt_repos = get_manifest()['apt-repos']
+    # We want the final sources.list to be in the rootfs image
+    apt_repos = get_apt_repos(check_custom=False)
     apt_sources = [f'deb {apt_repos["url"]} {apt_repos["distribution"]} {apt_repos["components"]}']
     for repo in apt_repos['additional']:
         apt_sources.append(f'deb {repo["url"]} {repo["distribution"]} {repo["component"]}')

--- a/scale_build/utils/manifest.py
+++ b/scale_build/utils/manifest.py
@@ -80,6 +80,8 @@ MANIFEST_SCHEMA = {
         'apt-repos': {
             'type': 'object',
             'properties': {
+                'base-url': {'type': 'string', 'pattern': '.*/$'},
+                'base-url-internal': {'type': 'string', 'pattern': '.*/$'},
                 'url': {'type': 'string'},
                 'distribution': {'type': 'string'},
                 'components': {'type': 'string'},


### PR DESCRIPTION
This PR continues on the work we did in https://github.com/truenas/scale-build/pull/754 but additionally it makes sure the final resulting image does not has internal apt mirrors specified as those scale installations will not be able to access iX internal apt mirrors and also it ensures that cache is invalidated if apt mirrors change i.e internal apt mirror is no longer desired for a build.