### PR TITLE
NAS-130427 / 25.04 / Update Linux kernel to 6.12 LTS

### DIFF
--- a/conf/build.manifest
+++ b/conf/build.manifest
@@ -338,7 +338,7 @@ sources:
     - "./pull.sh"
 - name: kernel
   repo: https://github.com/truenas/linux
-  branch: truenas/linux-6.6
+  branch: truenas/linux-6.12
   batch_priority: 0
   supports_ccache: true
   env:
@@ -347,7 +347,7 @@ sources:
   predepscmd:
     - "apt install -y flex bison dwarves libssl-dev devscripts"
     # Install dependencies to build perf
-    - "apt install -y libelf-dev libdw-dev systemtap-sdt-dev libunwind-dev libslang2-dev libperl-dev binutils-dev libiberty-dev python3 python3-setuptools python3-dev liblzma-dev libzstd-dev libcap-dev libnuma-dev libbabeltrace-dev openjdk-17-jdk"
+    - "apt install -y libelf-dev libdw-dev systemtap-sdt-dev libunwind-dev libslang2-dev libperl-dev binutils-dev libiberty-dev python3 python3-setuptools python3-dev liblzma-dev libzstd-dev libcap-dev libnuma-dev libbabeltrace-dev openjdk-17-jdk libcapstone-dev llvm-dev"
     # We remove git files because kernel makefile tries to interact with git for determining version
     # which results in misconfigured version due to our debian based changes
     - "rm -rf .git .gitattributes .gitignore"
@@ -391,7 +391,7 @@ sources:
   branch: truenas/zfs-2.3-release
   env:
     KVERS: "$(shell apt info linux-headers-truenas-production-amd64 | awk '/Source:/ { print $$2}' | sed 's/linux-//')"
-    KSRC: "/usr/src/linux-headers-$(KVERS)"
+    KSRC: "/usr/src/linux-headers-truenas-production-amd64"
     KOBJ: "$(KSRC)"
   predepscmd:
     - "cp -r contrib/debian debian"
@@ -417,7 +417,7 @@ sources:
       batch_priority: 0
       env:
         KVERS: "$(shell apt info linux-headers-truenas-debug-amd64 | awk '/Source:/ { print $$2}' | sed 's/linux-//')"
-        KSRC: "/usr/src/linux-headers-$(KVERS)"
+        KSRC: "/usr/src/linux-headers-truenas-debug-amd64"
         KOBJ: "$(KSRC)"
       predepscmd:
         - "cp -r contrib/debian debian"


### PR DESCRIPTION
Build Fangtooth nightlies with Linux 6.12 LTS.

All relevant PRs have been merged. A final build is running [here](http://jenkins.eng.ixsystems.net:8080/job/master/job/custom/748/console). 