### PR TITLE
NAS-132388 / 25.04 / Save snmp config directory in upgrades

### DIFF
--- a/truenas_install/__main__.py
+++ b/truenas_install/__main__.py
@@ -455,6 +455,8 @@ def main():
                         rsync.append("var/lib/libvirt/qemu/nvram")
                     if os.path.exists(f"{old_root}/var/lib/netdata"):
                         rsync.append("var/lib/netdata")
+                    if os.path.exists(f"{old_root}/var/lib/snmp"):
+                        rsync.append("var/lib/snmp")
                     if os.path.exists(f"{old_root}/var/lib/syslog-ng/syslog-ng.persist"):
                         rsync.append("var/lib/syslog-ng/syslog-ng.persist")
                     if "var/log" not in cloned_datasets:


### PR DESCRIPTION
SNMP uses /var/lib/snmp to hold it's configuration, including v3 user information.
This directory should be preserved across an upgrade.

This PR adds preservation of the SNMP configuration directory during an upgrade.
This same fix is valid for backport to 24.10.2.