### PR TITLE
NAS-132949 / 25.04 / go back to sha1 for manifest files

### DIFF
--- a/scale_build/image/manifest.py
+++ b/scale_build/image/manifest.py
@@ -36,6 +36,7 @@ def build_manifest():
         for file in files:
             abspath = os.path.join(root, file)
             with open(abspath, 'rb') as f:
+                # FIXME: before we release 25.04.0 proper, change this to sha256
                 checksums[os.path.relpath(abspath, UPDATE_DIR)] = hashlib.file_digest(f, 'sha1').hexdigest()
 
     with open(os.path.join(UPDATE_DIR, 'manifest.json'), "w") as f:

--- a/scale_build/image/manifest.py
+++ b/scale_build/image/manifest.py
@@ -36,7 +36,7 @@ def build_manifest():
         for file in files:
             abspath = os.path.join(root, file)
             with open(abspath, 'rb') as f:
-                checksums[os.path.relpath(abspath, UPDATE_DIR)] = hashlib.file_digest(f, 'sha256').hexdigest()
+                checksums[os.path.relpath(abspath, UPDATE_DIR)] = hashlib.file_digest(f, 'sha1').hexdigest()
 
     with open(os.path.join(UPDATE_DIR, 'manifest.json'), "w") as f:
         f.write(json.dumps({


### PR DESCRIPTION
We need to go back to SHA1 for these files because the code that does the validation is on the _running_ install of SCALE. I can leave the `sha256` changes middlewared land, but changing this needs to happen a few weeks later. (To give time for people running nightlies to have the new code.).