### PR TITLE
NAS-132964 / 25.04 / Add audit rules to build

### DIFF
--- a/conf/build.manifest
+++ b/conf/build.manifest
@@ -150,6 +150,8 @@ base-packages:
   # So until we can figure out how to mark packages as dependencies
   # without installing non-dependent packages, this will have to suffice
   install_recommends: false
+- name: truenas-audit-rules
+  install_recommends: false
 
 #
 # Packages which are removed from the base TrueNAS SCALE System by default
@@ -651,6 +653,10 @@ sources:
     - "apt install -y python3-docs-theme python3-sphinx texinfo wget"
     - "wget https://www.python.org/ftp/python/3.11.9/Python-3.11.9.tar.xz"
     - "tar --strip-components=1 -xvf Python-3.11.9.tar.xz"
+- name: truenas_audit_rules
+  repo: https://github.com/truenas/audit_rules.git
+  branch: master
+  generate_version: false
 
 # Nvidia extensions versions
 ############################################################################

--- a/scale_build/image/mtree.py
+++ b/scale_build/image/mtree.py
@@ -9,7 +9,7 @@ from tempfile import NamedTemporaryFile
 
 MTREE_FILE_NAME = 'rootfs.mtree'
 MTREE_UPDATE_FILE = f'{RELEASE_DIR}/{MTREE_FILE_NAME}'
-MTREE_DIRS = ['boot', 'etc', 'usr', 'opt', 'var']
+MTREE_DIRS = ['boot', 'etc', 'usr', 'opt', 'var', 'conf/audit_rules']
 
 # The following is list of default etc files to remove from our image before we
 # generate mtree file and then the squashfs filesystem. Generally we should put

--- a/scale_build/image/update.py
+++ b/scale_build/image/update.py
@@ -33,6 +33,13 @@ def build_rootfs_image():
 
     version = get_version()
 
+    # Generate audit rules
+    gencmd = os.path.join(CHROOT_BASEDIR, 'conf', 'audit_rules', 'privileged-rules.py')
+    priv_rule_file = os.path.join(CHROOT_BASEDIR, 'conf', 'audit_rules', '31-privileged.rules')
+    run([gencmd, '--target_dir', CHROOT_BASEDIR, '--privilege_file', priv_rule_file])
+    # Remove the audit file generation script
+    os.unlink(gencmd)
+
     # Generate mtree of relevant root filesystem directories
     mtree_file = generate_mtree(CHROOT_BASEDIR, version)
     shutil.copyfile(mtree_file, os.path.join(CHROOT_BASEDIR, 'conf', 'rootfs.mtree'))


### PR DESCRIPTION
This commit adds the audit rules package to the build and adds a step in which we generate the privileged rules set based on the update file before generating mtree.