### PR TITLE
NAS-133071 / 25.04 / Add SCST-related packages to base install

### DIFF
--- a/conf/build.manifest
+++ b/conf/build.manifest
@@ -117,6 +117,12 @@ base-packages:
   install_recommends: true
 - name: qemu-guest-agent
   install_recommends: true
+- name: iscsi-scst
+  install_recommends: true
+- name: scst
+  install_recommends: true
+- name: scstadmin
+  install_recommends: true
 - name: scst-dbg
   install_recommends: true
 - name: squashfs-tools


### PR DESCRIPTION
These were originally provided by the debian control file for middleware.