### PR TITLE
NAS-132983 / 25.04 / Add prefix argument to privileged audit rules

### DIFF
--- a/scale_build/image/update.py
+++ b/scale_build/image/update.py
@@ -36,7 +36,7 @@ def build_rootfs_image():
     # Generate audit rules
     gencmd = os.path.join(CHROOT_BASEDIR, 'conf', 'audit_rules', 'privileged-rules.py')
     priv_rule_file = os.path.join(CHROOT_BASEDIR, 'conf', 'audit_rules', '31-privileged.rules')
-    run([gencmd, '--target_dir', CHROOT_BASEDIR, '--privilege_file', priv_rule_file])
+    run([gencmd, '--target_dir', CHROOT_BASEDIR, '--privilege_file', priv_rule_file, '--prefix', CHROOT_BASEDIR])
     # Remove the audit file generation script
     os.unlink(gencmd)
 


### PR DESCRIPTION
We need to strip the chroot basedir prefix and make these files have absolute paths.