### PR TITLE
NAS-133293 / 25.04 / remove psutil from truenas_install

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,6 @@ idna==3.7
 jsonschema==3.2.0
 packaging==21.3
 pexpect==4.8.0
-psutil==5.8.0
 ptyprocess==0.7.0
 pyparsing==3.0.9
 PyYAML==6.0.1

--- a/scale_build/utils/system.py
+++ b/scale_build/utils/system.py
@@ -1,8 +1,12 @@
-import psutil
+from functools import cache
+
+REQUIRED_RAM_GB = 16 * (1024 ** 3)
+
+__all__ = ("has_low_ram",)
 
 
-REQUIRED_RAM = 16  # GB
-
-
+@cache
 def has_low_ram():
-    return psutil.virtual_memory().total < REQUIRED_RAM * 1024 * 1024 * 1024
+    with open('/proc/meminfo') as f:
+        for line in filter(lambda x: 'MemTotal' in x, f):
+            return int(line.split()[1]) * 1024 < REQUIRED_RAM_GB

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,6 @@ setup(
     install_requires=[
         'coloredlogs',
         'toposort',
-        'psutil',
         'requests',
         'pyyaml'
     ],

--- a/truenas_install/utils.py
+++ b/truenas_install/utils.py
@@ -33,11 +33,10 @@ class MntEntry:
     mount_id: int
     parent_id: int
     device_id: DevIdEntry
-    maj_min: int
     root: str
     mountpoint: str
     mount_opts: list[str]
-    fstype: str
+    fs_type: str
     mount_source: str
     super_opts: list[str]
 

--- a/truenas_install/utils.py
+++ b/truenas_install/utils.py
@@ -1,0 +1,77 @@
+from collections.abc import Generator
+from dataclasses import dataclass
+from functools import cached_property
+from os import makedev, scandir
+
+__all__ = ("get_pids", "getmntinfo",)
+
+
+@dataclass(frozen=True, kw_only=True)
+class PidEntry:
+    cmdline: bytes
+    pid: int
+
+    @cached_property
+    def name(self) -> bytes:
+        """The name of process as described in man 2 PR_SET_NAME"""
+        with open(f"/proc/{self.pid}/status", "rb") as f:
+            # first line in this file is name of process
+            # and this is in procfs, which is considered
+            # part of linux's ABI and is stable
+            return f.readline().split(b"\t", 1)[-1].strip()
+
+
+@dataclass(slots=True, frozen=True, kw_only=True)
+class DevIdEntry:
+    major: int
+    minor: int
+    dev_t: int
+
+
+@dataclass(slots=True, frozen=True, kw_only=True)
+class MntEntry:
+    mount_id: int
+    parent_id: int
+    device_id: DevIdEntry
+    maj_min: int
+    root: str
+    mountpoint: str
+    mount_opts: list[str]
+    fstype: str
+    mount_source: str
+    super_opts: list[str]
+
+
+def get_pids() -> Generator[PidEntry] | None:
+    """Get the currently running processes on the OS"""
+    with scandir("/proc/") as sdir:
+        for i in filter(lambda x: x.name.isdigit(), sdir):
+            try:
+                with open(f"{i.path}/cmdline", "rb") as f:
+                    cmdline = f.read().replace(b"\x00", b" ")
+                yield PidEntry(cmdline=cmdline, pid=int(i.name))
+            except FileNotFoundError:
+                # process could have gone away
+                pass
+
+
+def getmntinfo() -> Generator[MntEntry]:
+    with open('/proc/self/mountinfo') as f:
+        for line in f:
+            mnt_id, parent_id, maj_min, root, mp, opts, extra = line.split(" ", 6)
+            fstype, mnt_src, super_opts = extra.split(' - ')[1].split()
+            major, minor = maj_min.split(':')
+            major, minor = int(major), int(minor)
+            devid = makedev(major, minor)
+            deventry = DevIdEntry(major=major, minor=minor, dev_t=devid)
+            yield MntEntry(**{
+                'mount_id': int(mnt_id),
+                'parent_id': int(parent_id),
+                'device_id': deventry,
+                'root': root.replace('\\040', ' '),
+                'mountpoint': mp.replace('\\040', ' '),
+                'mount_opts': opts.upper().split(','),
+                'fs_type': fstype,
+                'mount_source': mnt_src.replace('\\040', ' '),
+                'super_opts': super_opts.upper().split(','),
+            })


### PR DESCRIPTION
Similar to what was done in https://github.com/truenas/middleware/pull/15227, this removes psutil from truenas_install. The logic added in `utils.py` was copy and pasted from `utils/os.py` and `utils/mount.py` in the truenas/middleware repo.