### PR TITLE
NAS-133580 / 25.04 / fix nvidia driver URL

### DIFF
--- a/scale_build/extensions.py
+++ b/scale_build/extensions.py
@@ -152,7 +152,7 @@ class NvidiaExtension(Extension):
                     "https://nvidia.github.io/libnvidia-container/stable/deb/$(ARCH) /")
 
     def download_nvidia_driver(self):
-        prefix = "https://download.nvidia.com/XFree86/Linux-x86_64"
+        prefix = "https://us.download.nvidia.com/XFree86/Linux-x86_64"
 
         version = get_manifest()["extensions"]["nvidia"]["current"]
         filename = f"NVIDIA-Linux-x86_64-{version}-no-compat32.run"


### PR DESCRIPTION
The issue is not that the driver updated (as was described in 192378449afb3c4e0328b527973e5c1fb4a2e84f), the issue is that `download.nvidia.com` has dead links. Using `us.download.nvidia.com` fixes the issue.