### PR TITLE
NAS-133696 / 25.04 / Update scst from truenas-3.9.0-pre to truenas-3.10.0-pre

### DIFF
--- a/conf/build.manifest
+++ b/conf/build.manifest
@@ -501,7 +501,7 @@ sources:
   explicit_deps:
     - kernel
     - kernel-dbg
-  branch: truenas-3.9.0-pre
+  branch: truenas-3.10.0-pre
   subpackages:
     - name: scst-dbg
       generate_version: false


### PR DESCRIPTION
This commit updates SCST from `truenas-3.9.0-pre` to `truenas-3.10.0-pre` (i.e. tip).

----
CI test run [here](http://jenkins.eng.ixsystems.net:8080/job/tests/job/api_tests/2649/), which is exhibiting similar issues as regular recent runs.  Installed on regular hardware too.