### PR TITLE
NAS-133968 / 25.10 / Update mtree to better support cryptographic verification for STIG

### DIFF
--- a/scale_build/image/mtree.py
+++ b/scale_build/image/mtree.py
@@ -45,7 +45,7 @@ ETC_FILES_TO_REMOVE = [
     'etc/rc3.d/K01ssh',
     'etc/rc4.d/K01ssh',
     'etc/rc5.d/K01ssh',
-    'etc/initramfs-tools/modules',  # These three are not used by systemd
+    'etc/initramfs-tools/modules',  # These two are not used by systemd
     'etc/modules',
 ]
 


### PR DESCRIPTION
Update mtree to support cryptographic verification for STIG
-------------------------------------------------------------------
Our goal is to have zero discrepancies at install.

- Added a few files to the `delete` list and `ignore` list.  These were discovered during testing.
- Created a list of files that require `chmod`

Explanation of the files added to delete:
- `etc/audit/rules.d/audit.rules`  is not used by TrueNAS.  This file is deleted by the audit subsystem.
- `etc/rc[2345].d/K01ssh` are symlinks used by the legacy init.d.  The systemd subsystem deletes these on ssh start.