### PR TITLE
NAS-132120 / 25.04-RC.1 / Add nfs-utils package to base install (by anodos325)

### DIFF
--- a/conf/build.manifest
+++ b/conf/build.manifest
@@ -667,6 +667,10 @@ sources:
   repo: https://github.com/truenas/audit_rules.git
   branch: stable/fangtooth
   generate_version: false
+- name: nfs_utils
+  repo: https://github.com/truenas/nfs-utils.git
+  branch: stable/fangtooth
+  generate_version: false
 
 # Nvidia extensions versions
 ############################################################################


### PR DESCRIPTION
This commit adds our custom version of nfs-utils to the base install.

Original PR: https://github.com/truenas/scale-build/pull/825
Jira URL: https://ixsystems.atlassian.net/browse/NAS-132120