### PR TITLE
NAS-133958 / 25.04-RC.1 / Remove legacy VM usages from build (by Qubad786)

### DIFF
--- a/conf/reference-files/etc/group
+++ b/conf/reference-files/etc/group
@@ -65,7 +65,6 @@ tcpdump:x:123:
 rdma:x:124:
 nut:x:126:
 ladvd:x:127:
-libvirt:x:128:
 nova:x:129:
 builtin_administrators:x:544:
 builtin_users:x:545:
@@ -75,7 +74,6 @@ webdav:x:666:
 truenas_readonly_administrators:x:951:
 truenas_sharing_administrators:x:952:
 docker:x:999:
-libvirt-qemu:x:986:libvirt-qemu
 haproxy:x:130:
 uuidd:x:131:
 i2c:x:132:

--- a/conf/reference-files/etc/passwd
+++ b/conf/reference-files/etc/passwd
@@ -42,7 +42,6 @@ ladvd:x:124:127:ladvd user:/var/empty:/usr/sbin/nologin
 nova:x:125:129::/var/lib/nova:/bin/bash
 apps:x:568:568:Unprivileged Apps User:/var/empty:/usr/sbin/nologin
 webdav:x:666:666:WebDAV Anonymous User:/var/empty:/usr/sbin/nologin
-libvirt-qemu:x:986:106:Libvirt Qemu,,,:/var/lib/libvirt:/usr/sbin/nologin
 haproxy:x:126:130::/var/lib/haproxy:/usr/sbin/nologin
 uuidd:x:127:131::/run/uuidd:/usr/sbin/nologin
 ntpsec:x:128:135::/nonexistent:/usr/sbin/nologin

--- a/truenas_install/__main__.py
+++ b/truenas_install/__main__.py
@@ -447,8 +447,6 @@ def main():
                     rsync.append("etc/machine-id")
                     if "home" not in cloned_datasets:
                         rsync.append("home")
-                    if os.path.exists(f"{old_root}/var/lib/libvirt/qemu/nvram"):
-                        rsync.append("var/lib/libvirt/qemu/nvram")
                     if os.path.exists(f"{old_root}/var/lib/netdata"):
                         rsync.append("var/lib/netdata")
                     if os.path.exists(f"{old_root}/var/lib/snmp"):


### PR DESCRIPTION
## Context

Legacy VM plugin is being removed from TrueNAS.

Original PR: https://github.com/truenas/scale-build/pull/823
Jira URL: https://ixsystems.atlassian.net/browse/NAS-133958