### PR TITLE
NAS-134219 / 25.10 / Remove 744 mode set on /var/lib/incus.  Use the Debian default of 755.

### DIFF
--- a/truenas_install/fhs.py
+++ b/truenas_install/fhs.py
@@ -160,7 +160,6 @@ TRUENAS_DATASETS = [
     {
         'name':  'var/lib/incus',
         'options': ['NOSETUID', 'NOACL', 'NOATIME', 'DEV'],
-        'mode': 0o744,
     },
     {
         'name':  'var/log',


### PR DESCRIPTION
Remove the `744` mode setting on /var/lib/incus.  We will use the Debian default: `755`