### PR TITLE
NAS-135571 / 25.10 / Allow specifying secret_env for packages as env variables

### DIFF
--- a/scale_build/config.py
+++ b/scale_build/config.py
@@ -42,6 +42,7 @@ GITHUB_TOKEN = get_env_variable('GITHUB_TOKEN', str)
 PACKAGE_IDENTITY_FILE_PATH_OVERRIDES = {}
 PARALLEL_BUILD = get_env_variable('PARALLEL_BUILDS', int, (max(cpu_count(), 8) / 4))
 PKG_DEBUG = get_env_variable('PKG_DEBUG', bool, 0)
+SECRET_ENV_VARS = {}
 SIGNING_KEY = get_env_variable('SIGNING_KEY', str)
 SIGNING_PASSWORD = get_env_variable('SIGNING_PASSWORD', str)
 SKIP_SOURCE_REPO_VALIDATION = get_env_variable('SKIP_SOURCE_REPO_VALIDATION', bool)
@@ -59,3 +60,5 @@ for k, v in environ.items():
         BRANCH_OVERRIDES[k[:-(len('_OVERRIDE'))]] = v
     elif k.endswith(IDENTITY_FILE_PATH_OVERRIDE_SUFFIX):
         PACKAGE_IDENTITY_FILE_PATH_OVERRIDES[k[:-(len(IDENTITY_FILE_PATH_OVERRIDE_SUFFIX))]] = v
+    elif k.startswith('SECRET_'):
+        SECRET_ENV_VARS[k[len('SECRET_'):]] = v

--- a/scale_build/utils/manifest.py
+++ b/scale_build/utils/manifest.py
@@ -6,7 +6,7 @@ import yaml
 
 from urllib.parse import urlparse
 
-from scale_build.config import APT_BASE_CUSTOM, APT_INTERNAL_BUILD, SKIP_SOURCE_REPO_VALIDATION, TRAIN
+from scale_build.config import APT_BASE_CUSTOM, APT_INTERNAL_BUILD, SKIP_SOURCE_REPO_VALIDATION, TRAIN, SECRET_ENV_VARS
 from scale_build.exceptions import CallError, MissingManifest
 from scale_build.utils.paths import MANIFEST, SECRETS_FILE
 
@@ -209,9 +209,9 @@ def get_secret_env():
     except yaml.YAMLError:
         raise CallError('A valid yaml file is expected for secrets')
     except FileNotFoundError:
-        return {}
+        return {} | SECRET_ENV_VARS
     else:
-        return secrets
+        return secrets | SECRET_ENV_VARS
 
 
 def get_manifest_str():


### PR DESCRIPTION
This commit will allow to specify secret env which a package during build might require using environment variables (we support a dedicated `secrets.yaml` file already for this).
i.e
```
env SECRET_SENTRY_AUTH_TOKEN="SOME_TOKEN" make packages PACKAGES="truenas_webui"
```