### PR TITLE
NAS-135854 / 25.04.1 / Add python version check to truenas_install module (by anodos325)

### DIFF
--- a/.github/workflows/manifest.yml
+++ b/.github/workflows/manifest.yml
@@ -9,10 +9,10 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
-    - name: Set up Python 3.9
-      uses: actions/setup-python@v1
+    - name: Set up Python 3.10
+      uses: actions/setup-python@v5
       with:
-        python-version: 3.9
+        python-version: '3.10'
     - name: Validating manifest
       run: |
         python -m pip install --upgrade pip

--- a/truenas_install/__main__.py
+++ b/truenas_install/__main__.py
@@ -4,6 +4,15 @@ import platform
 import sys
 
 
+LEGACY_TRUENAS_VERSION_ERR_MSG = (
+    "Migrating TrueNAS CORE to TrueNAS SCALE 24.10 (or later) using update file upload is not supported. "
+    "Please migrate with the latest 24.04 release update file or back up the TrueNAS configuration, perform a "
+    "fresh install, and restore from the configuration backup."
+)
+INSTALLER_PYTHON_MIN_VERSION_MINOR = 10
+version = sys.version_info
+
+
 def write_error(error: str, raise_=False, prefix="Error: "):
     sys.stdout.write(json.dumps({"error": prefix + error}) + "\n")
     sys.stdout.flush()
@@ -14,12 +23,11 @@ def write_error(error: str, raise_=False, prefix="Error: "):
 
 if __name__ == "__main__":
     if platform.system().upper() == "FREEBSD":
-        write_error(
-            "Migrating TrueNAS CORE to TrueNAS SCALE 24.10 (or later) using update file upload is not supported. "
-            "Please migrate with the latest 24.04 release update file or back up the TrueNAS configuration, perform a "
-            "fresh install, and restore from the configuration backup."
-        )
+        write_error(LEGACY_TRUENAS_VERSION_ERR_MSG)
         sys.exit(2)
+
+if version.major < 3 or version.minor < INSTALLER_PYTHON_MIN_VERSION_MINOR:
+    write_error(LEGACY_TRUENAS_VERSION_ERR_MSG, raise_=True)
 
 
 from collections import defaultdict  # noqa


### PR DESCRIPTION
This commit adds a basic python version check to the truenas_install module so that we can raise a useful error message if someone is somehow running the installer in the context of a really old python version (like in 13).

Original PR: https://github.com/truenas/scale-build/pull/857
Jira URL: https://ixsystems.atlassian.net/browse/NAS-135854