### PR TITLE
Ensure consistent home directory handling in reference file comparisons

### DIFF
--- a/scale_build/bootstrap/cache.py
+++ b/scale_build/bootstrap/cache.py
@@ -56,7 +56,10 @@ class CacheMixin:
 
         if intact:
             self.restore_cache(self.chroot_basedir)
-            for reference_file, diff in compare_reference_files(cut_nonexistent_user_group_membership=True):
+            for reference_file, diff in compare_reference_files(
+                cut_nonexistent_user_group_membership=True,
+                default_homedir='/var/empty'
+            ):
                 if diff:
                     intact = False
                     self.logger.debug(

--- a/scale_build/update_image.py
+++ b/scale_build/update_image.py
@@ -64,7 +64,7 @@ def build_update_image_impl():
 
             install_rootfs_packages()
 
-            for reference_file, diff in compare_reference_files():
+            for reference_file, diff in compare_reference_files(default_homedir='/var/empty'):
                 if diff:
                     raise CallError(
                         f'Reference file {reference_file!r} changed.\n'


### PR DESCRIPTION
Always use '/var/empty' when comparing reference files to match SCALE's standard home directory for system users, preventing false cache invalidation due to debian's '/nonexistent' default.