### PR TITLE
NAS-136140 / 25.04.2 / Maintain logs across upgrades (by mgrimesix)

### DIFF
--- a/truenas_install/__main__.py
+++ b/truenas_install/__main__.py
@@ -285,7 +285,7 @@ def main():
     if old_root is not None:
         for i in getmntinfo():
             if i.mountpoint == old_root:
-                old_root_dataset == i.mount_source
+                old_root_dataset = i.mount_source
                 break
 
     write_progress(0, "Creating dataset")


### PR DESCRIPTION
A typo in the code prevented cloning the necessary datasets during upgrades.
This effected syslog, audit.log and all logs that relied on the clone.

**Before upgrade. Note the timestamps for comparison**
---------------------------------------
```
root@upgrade-testing[~]# cat /etc/version
25.04.0
root@upgrade-testing[~]# head /var/log/syslog
Jun  6 15:21:51 truenas syslog-ng[2008]: syslog-ng starting up; version='3.38.1'
Jun  6 08:07:26 truenas kernel: Linux version 6.12.15-production+truenas (root@tnsbuilds01.tn.ixsystems.net)
Jun  6 08:07:26 truenas kernel: Command line: BOOT_IMAGE=/ROOT/25.04.0@/boot/vmlinuz-6.12.15-production+truenas 
root@upgrade-testing[~]#
root@upgrade-testing[~]# head /var/log/audit/audit.log
type=DAEMON_START msg=audit(1749248066.077:1771): op=start ver=3.0.9 format=enriched kernel=6.12.15-
type=AVC msg=audit(1749248066.178:3): apparmor="STATUS" operation="profile_load" profile="unconfined" 
type=AVC msg=audit(1749248066.178:4): apparmor="STATUS" operation="profile_load" profile="unconfined" 

```
**After upgrade _without_ the fix (with hostname set):**
-------------------------------------
```
root@upgrade-testing[~]# cat /etc/version
25.10.0-MASTER-20250610-144806
root@upgrade-testing[~]#
root@upgrade-testing[~]# head /var/log/syslog
Jun 10 19:02:56 upgrade-testing syslog-ng[2084]: syslog-ng starting up; version='3.38.1'
Jun 10 19:00:59 upgrade-testing kernel: Linux version 6.12.25-production+truenas (root@eng-build-vm-master01)
Jun 10 19:00:59 upgrade-testing kernel: Command line: BOOT_IMAGE=/ROOT/25.10.0-MASTER-20250610-
root@upgrade-testing[~]#
root@upgrade-testing[~]# head /var/log/audit/audit.log
type=DAEMON_START msg=audit(1749607374.014:8029): op=start ver=3.0.9 format=enriched kernel=6.12.25-
type=AVC msg=audit(1749607374.092:3): apparmor="STATUS" operation="profile_load" profile="unconfined" 
type=AVC msg=audit(1749607374.092:4): apparmor="STATUS" operation="profile_load" profile="unconfined" 

```
**After upgrade _with_ the fix (with hostname set) - timestamps match pre-update:**
---------------------------------------
```
root@upgrade-testing[~]# cat /etc/version
25.10.0-MASTER-20250610-182906
root@upgrade-testing[~]#
root@upgrade-testing[~]# head /var/log/syslog
Jun  6 15:21:51 truenas syslog-ng[2008]: syslog-ng starting up; version='3.38.1'
Jun  6 08:07:26 truenas kernel: Linux version 6.12.15-production+truenas (root@tnsbuilds01.tn.ixsystems.net)
Jun  6 08:07:26 truenas kernel: Command line: BOOT_IMAGE=/ROOT/25.04.0@/boot/vmlinuz-6.12.15-production+truenas 
root@upgrade-testing[~]#
root@upgrade-testing[~]# head /var/log/audit/audit.log
type=DAEMON_START msg=audit(1749248066.077:1771): op=start ver=3.0.9 format=enriched kernel=6.12.15-
type=AVC msg=audit(1749248066.178:3): apparmor="STATUS" operation="profile_load" profile="unconfined" 
type=AVC msg=audit(1749248066.178:4): apparmor="STATUS" operation="profile_load" profile="unconfined" 
```

Original PR: https://github.com/truenas/scale-build/pull/872
