### PR TITLE
grub: skip loading bli module when booting the ISO installer

### DIFF
--- a/scripts/grub.cfg
+++ b/scripts/grub.cfg
@@ -80,4 +80,8 @@ menuentry --hotkey=j --id=serial 'Start $vendor Installation (115200 baud)' {
     linux    /vmlinuz gfxpayload=text quiet nomodeset boot=live toram=filesystem.squashfs $gfx_console $serial_console
     initrd   /initrd.img
 }
-insmod bli
+
+# Skip loading the bli module when booting from the installer ISO
+if [ ! -f /.disk/info ]; then
+    insmod bli
+fi


### PR DESCRIPTION
Installing the BLI module in the installer’s minimal EFI environment deadlocks, leading to an unresponsive black screen. We now only invoke insmod bli on real installations by detecting ISO boots via /.disk/info. This prevents the deadlock and blank screen on installer boots while ensuring BLI still loads correctly on standard boots.

### Testing
I have confirmed that this resolves the issue on the M60; @jordan-mcgillivray005 will verify the fix on the hardware where it was originally reported.