### PR TITLE
TEN-2441 Addition of releases.json file for nightly builds

### DIFF
--- a/jenkins/Publish-ISO
+++ b/jenkins/Publish-ISO
@@ -17,7 +17,6 @@ pipeline {
         copyArtifacts filter: '**/*.json', fingerprintArtifacts: true, flatten: true, projectName: 'Build - TrueNAS SCALE (Full - Nightly ISO)', selector: lastSuccessful(), target: 'upload/files'
         sh 'ssh jenkins@staging.sys.ixsystems.net mkdir -p /zdata/update.sys.truenas.net/scale/TrueNAS-SCALE-Goldeye-Nightlies || true'
         sh 'scp upload/files/manifest.json upload/files/TrueNAS-SCALE-*.update jenkins@staging.sys.ixsystems.net:/zdata/update.sys.truenas.net/scale/TrueNAS-SCALE-Goldeye-Nightlies/'
-        sh 'rm -rf upload/files'
       }
 	}
 	stage('Update Releases JSON') {
@@ -65,6 +64,7 @@ pipeline {
 			  
 			  // Upload updated releases.json
 			  sh '''scp upload/files/releases.json jenkins@staging.sys.ixsystems.net:/zdata/update.sys.truenas.net/scale/TrueNAS-SCALE-Goldeye-Nightlies/'''
+			  sh 'rm -rf upload/files'
 			}
 		}
 	}		

--- a/jenkins/Publish-ISO
+++ b/jenkins/Publish-ISO
@@ -42,10 +42,15 @@ pipeline {
 	    releaseEntry.profile = 'DEVELOPER'
 	    existingReleases[manifest.version] = releaseEntry
 	  
-	  // Keep only the last 30 entries (assuming chronological insertion order)
+	  // Keep only the last 30 entries by date
 	  if (existingReleases.size() > 30) {
-	    def entries = existingReleases.entrySet() as List
-	    def recentEntries = entries.drop(entries.size() - 30)
+	    // Sort entries by date and keep only the 30 most recent
+	    def sortedEntries = existingReleases.sort { a, b -> 
+	      Date.parse("yyyy-MM-dd'T'HH:mm:ss'Z'", b.value.date).compareTo(
+		Date.parse("yyyy-MM-dd'T'HH:mm:ss'Z'", a.value.date)
+	      )
+	    }
+	    def recentEntries = sortedEntries.take(30)
 	    existingReleases = [:]
 	    recentEntries.each { entry ->
 	      existingReleases[entry.key] = entry.value

--- a/jenkins/Publish-ISO
+++ b/jenkins/Publish-ISO
@@ -19,6 +19,54 @@ pipeline {
         sh 'scp upload/files/manifest.json upload/files/TrueNAS-SCALE-*.update jenkins@staging.sys.ixsystems.net:/zdata/update.sys.truenas.net/scale/TrueNAS-SCALE-Goldeye-Nightlies/'
         sh 'rm -rf upload/files'
       }
-    }
+	}
+	stage('Update Releases JSON') {
+		  steps {
+			script {
+			  // Download existing releases.json if it exists
+			  sh '''scp jenkins@staging.sys.ixsystems.net:/zdata/update.sys.truenas.net/scale/${TRUENAS_TRAIN}/releases.json upload/files/releases.json || echo "{}" > upload/files/releases.json'''
+			  
+			  // Read manifest.json and extract information
+			  def manifestContent = readFile('upload/files/manifest.json')
+			  def manifest = readJSON text: manifestContent
+			  
+			  // Read existing releases.json
+			  def existingReleasesContent = readFile('upload/files/releases.json')
+			  def existingReleases = readJSON text: existingReleasesContent
+			  
+			  // Add new release entry to existing releases dictionary
+			  existingReleases[manifest.version] = [
+				"profile": 'DEVELOPER',
+				"filename": manifest.filename,
+				"version": manifest.version,
+				"date": manifest.date,
+				"changelog": manifest.changelog,
+				"checksum": manifest.checksum,
+				"filesize": manifest.filesize
+			  ]
+			  
+			  // Keep only the last 30 entries by date
+			  if (existingReleases.size() > 30) {
+				// Sort entries by date and keep only the 30 most recent
+				def sortedEntries = existingReleases.sort { a, b -> 
+				  Date.parse("yyyy-MM-dd'T'HH:mm:ss'Z'", b.value.date).compareTo(
+					Date.parse("yyyy-MM-dd'T'HH:mm:ss'Z'", a.value.date)
+				  )
+				}
+				def recentEntries = sortedEntries.take(30)
+				existingReleases = [:]
+				recentEntries.each { entry ->
+				  existingReleases[entry.key] = entry.value
+				}
+			  }
+			  
+			  // Write updated releases.json
+			  writeJSON file: 'upload/files/releases.json', json: existingReleases, pretty: 4
+			  
+			  // Upload updated releases.json
+			  sh '''scp upload/files/releases.json jenkins@staging.sys.ixsystems.net:/zdata/update.sys.truenas.net/scale/${TRUENAS_TRAIN}/'''
+			}
+		}
+	}		
   }
 }

--- a/jenkins/Publish-ISO
+++ b/jenkins/Publish-ISO
@@ -24,7 +24,7 @@ pipeline {
 		  steps {
 			script {
 			  // Download existing releases.json if it exists
-			  sh '''scp jenkins@staging.sys.ixsystems.net:/zdata/update.sys.truenas.net/scale/${TRUENAS_TRAIN}/releases.json upload/files/releases.json || echo "{}" > upload/files/releases.json'''
+			  sh '''scp jenkins@staging.sys.ixsystems.net:/zdata/update.sys.truenas.net/scale/TrueNAS-SCALE-Goldeye-Nightlies/releases.json upload/files/releases.json || echo "{}" > upload/files/releases.json'''
 			  
 			  // Read manifest.json and extract information
 			  def manifestContent = readFile('upload/files/manifest.json')
@@ -64,7 +64,7 @@ pipeline {
 			  writeJSON file: 'upload/files/releases.json', json: existingReleases, pretty: 4
 			  
 			  // Upload updated releases.json
-			  sh '''scp upload/files/releases.json jenkins@staging.sys.ixsystems.net:/zdata/update.sys.truenas.net/scale/${TRUENAS_TRAIN}/'''
+			  sh '''scp upload/files/releases.json jenkins@staging.sys.ixsystems.net:/zdata/update.sys.truenas.net/scale/TrueNAS-SCALE-Goldeye-Nightlies/'''
 			}
 		}
 	}		

--- a/jenkins/Publish-ISO
+++ b/jenkins/Publish-ISO
@@ -35,7 +35,10 @@ pipeline {
 	  
 	    // Add new release entry to existing releases dictionary
 	    // Copy all manifest fields and add profile
-	    def releaseEntry = manifest.clone()
+	    def releaseEntry = [:]
+	    manifest.each { key, value ->
+	      releaseEntry[key] = value
+	    }
 	    releaseEntry.profile = 'DEVELOPER'
 	    existingReleases[manifest.version] = releaseEntry
 	  

--- a/jenkins/Publish-ISO
+++ b/jenkins/Publish-ISO
@@ -20,53 +20,53 @@ pipeline {
       }
 	}
 	stage('Update Releases JSON') {
-		  steps {
-			script {
-			  // Download existing releases.json if it exists
-			  sh '''scp jenkins@staging.sys.ixsystems.net:/zdata/update.sys.truenas.net/scale/TrueNAS-SCALE-Goldeye-Nightlies/releases.json upload/files/releases.json || echo "{}" > upload/files/releases.json'''
-			  
-			  // Read manifest.json and extract information
-			  def manifestContent = readFile('upload/files/manifest.json')
-			  def manifest = readJSON text: manifestContent
-			  
-			  // Read existing releases.json
-			  def existingReleasesContent = readFile('upload/files/releases.json')
-			  def existingReleases = readJSON text: existingReleasesContent
-			  
-			  // Add new release entry to existing releases dictionary
-			  existingReleases[manifest.version] = [
-				"profile": 'DEVELOPER',
-				"filename": manifest.filename,
-				"version": manifest.version,
-				"date": manifest.date,
-				"changelog": manifest.changelog,
-				"checksum": manifest.checksum,
-				"filesize": manifest.filesize
-			  ]
-			  
-			  // Keep only the last 30 entries by date
-			  if (existingReleases.size() > 30) {
-				// Sort entries by date and keep only the 30 most recent
-				def sortedEntries = existingReleases.sort { a, b -> 
-				  Date.parse("yyyy-MM-dd'T'HH:mm:ss'Z'", b.value.date).compareTo(
-					Date.parse("yyyy-MM-dd'T'HH:mm:ss'Z'", a.value.date)
-				  )
-				}
-				def recentEntries = sortedEntries.take(30)
-				existingReleases = [:]
-				recentEntries.each { entry ->
-				  existingReleases[entry.key] = entry.value
-				}
-			  }
-			  
-			  // Write updated releases.json
-			  writeJSON file: 'upload/files/releases.json', json: existingReleases, pretty: 4
-			  
-			  // Upload updated releases.json
-			  sh '''scp upload/files/releases.json jenkins@staging.sys.ixsystems.net:/zdata/update.sys.truenas.net/scale/TrueNAS-SCALE-Goldeye-Nightlies/'''
-			  sh 'rm -rf upload/files'
-			}
-		}
-	}		
+	  steps {
+	    script {
+	    // Download existing releases.json if it exists
+	    sh '''scp jenkins@staging.sys.ixsystems.net:/zdata/update.sys.truenas.net/scale/TrueNAS-SCALE-Goldeye-Nightlies/releases.json upload/files/releases.json || echo "{}" > upload/files/releases.json'''
+	  
+	    // Read manifest.json and extract information
+	    def manifestContent = readFile('upload/files/manifest.json')
+	    def manifest = readJSON text: manifestContent
+	  
+	    // Read existing releases.json
+	    def existingReleasesContent = readFile('upload/files/releases.json')
+	    def existingReleases = readJSON text: existingReleasesContent
+	  
+	    // Add new release entry to existing releases dictionary
+	    existingReleases[manifest.version] = [
+		"profile": 'DEVELOPER',
+		"filename": manifest.filename,
+		"version": manifest.version,
+		"date": manifest.date,
+		"changelog": manifest.changelog,
+		"checksum": manifest.checksum,
+		"filesize": manifest.filesize
+	    ]
+	  
+	  // Keep only the last 30 entries by date
+	  if (existingReleases.size() > 30) {
+	    // Sort entries by date and keep only the 30 most recent
+	    def sortedEntries = existingReleases.sort { a, b -> 
+	      Date.parse("yyyy-MM-dd'T'HH:mm:ss'Z'", b.value.date).compareTo(
+		Date.parse("yyyy-MM-dd'T'HH:mm:ss'Z'", a.value.date)
+	      )
+	    }
+	    def recentEntries = sortedEntries.take(30)
+	    existingReleases = [:]
+	    recentEntries.each { entry ->
+	      existingReleases[entry.key] = entry.value
+	    }
+	  }
+	  
+	  // Write updated releases.json
+	  writeJSON file: 'upload/files/releases.json', json: existingReleases, pretty: 4
+	  
+	  // Upload updated releases.json
+	  sh '''scp upload/files/releases.json jenkins@staging.sys.ixsystems.net:/zdata/update.sys.truenas.net/scale/TrueNAS-SCALE-Goldeye-Nightlies/'''
+	  sh 'rm -rf upload/files'
+	}
+       }
+     }		
   }
 }

--- a/jenkins/Publish-ISO
+++ b/jenkins/Publish-ISO
@@ -8,11 +8,11 @@ pipeline {
     stage('Upload') {
       steps {
         echo '*** Grabbing artifacts from Build - TrueNAS SCALE (Full - Nightly ISO) ***'
-        copyArtifacts filter: '**/*.iso', fingerprintArtifacts: true, flatten: true, projectName: 'Build - TrueNAS SCALE (Full - Nightly ISO)', selector: lastSuccessful(), target: 'upload/files'
-        copyArtifacts filter: '**/*.sha256', fingerprintArtifacts: true, flatten: true, projectName: 'Build - TrueNAS SCALE (Full - Nightly ISO)', selector: lastSuccessful(), target: 'upload/files'
-        sh 'ssh jenkins@staging.sys.ixsystems.net mkdir -p /zdata/download.sys.truenas.net/truenas-scale-goldeye-nightly/ || true'
-        sh 'scp upload/files/TrueNAS-SCALE*.iso upload/files/TrueNAS-SCALE*.iso.sha256 jenkins@staging.sys.ixsystems.net:/zdata/download.sys.truenas.net/truenas-scale-goldeye-nightly/'
-        sh 'rm -rf upload/files'
+        // copyArtifacts filter: '**/*.iso', fingerprintArtifacts: true, flatten: true, projectName: 'Build - TrueNAS SCALE (Full - Nightly ISO)', selector: lastSuccessful(), target: 'upload/files'
+        // copyArtifacts filter: '**/*.sha256', fingerprintArtifacts: true, flatten: true, projectName: 'Build - TrueNAS SCALE (Full - Nightly ISO)', selector: lastSuccessful(), target: 'upload/files'
+        // sh 'ssh jenkins@staging.sys.ixsystems.net mkdir -p /zdata/download.sys.truenas.net/truenas-scale-goldeye-nightly/ || true'
+        // sh 'scp upload/files/TrueNAS-SCALE*.iso upload/files/TrueNAS-SCALE*.iso.sha256 jenkins@staging.sys.ixsystems.net:/zdata/download.sys.truenas.net/truenas-scale-goldeye-nightly/'
+        // sh 'rm -rf upload/files'
         copyArtifacts filter: '**/*.update', fingerprintArtifacts: true, flatten: true, projectName: 'Build - TrueNAS SCALE (Full - Nightly ISO)', selector: lastSuccessful(), target: 'upload/files'
         copyArtifacts filter: '**/*.json', fingerprintArtifacts: true, flatten: true, projectName: 'Build - TrueNAS SCALE (Full - Nightly ISO)', selector: lastSuccessful(), target: 'upload/files'
         sh 'ssh jenkins@staging.sys.ixsystems.net mkdir -p /zdata/update.sys.truenas.net/scale/TrueNAS-SCALE-Goldeye-Nightlies || true'

--- a/jenkins/Publish-ISO
+++ b/jenkins/Publish-ISO
@@ -8,11 +8,11 @@ pipeline {
     stage('Upload') {
       steps {
         echo '*** Grabbing artifacts from Build - TrueNAS SCALE (Full - Nightly ISO) ***'
-        // copyArtifacts filter: '**/*.iso', fingerprintArtifacts: true, flatten: true, projectName: 'Build - TrueNAS SCALE (Full - Nightly ISO)', selector: lastSuccessful(), target: 'upload/files'
-        // copyArtifacts filter: '**/*.sha256', fingerprintArtifacts: true, flatten: true, projectName: 'Build - TrueNAS SCALE (Full - Nightly ISO)', selector: lastSuccessful(), target: 'upload/files'
-        // sh 'ssh jenkins@staging.sys.ixsystems.net mkdir -p /zdata/download.sys.truenas.net/truenas-scale-goldeye-nightly/ || true'
-        // sh 'scp upload/files/TrueNAS-SCALE*.iso upload/files/TrueNAS-SCALE*.iso.sha256 jenkins@staging.sys.ixsystems.net:/zdata/download.sys.truenas.net/truenas-scale-goldeye-nightly/'
-        // sh 'rm -rf upload/files'
+        copyArtifacts filter: '**/*.iso', fingerprintArtifacts: true, flatten: true, projectName: 'Build - TrueNAS SCALE (Full - Nightly ISO)', selector: lastSuccessful(), target: 'upload/files'
+        copyArtifacts filter: '**/*.sha256', fingerprintArtifacts: true, flatten: true, projectName: 'Build - TrueNAS SCALE (Full - Nightly ISO)', selector: lastSuccessful(), target: 'upload/files'
+        sh 'ssh jenkins@staging.sys.ixsystems.net mkdir -p /zdata/download.sys.truenas.net/truenas-scale-goldeye-nightly/ || true'
+        sh 'scp upload/files/TrueNAS-SCALE*.iso upload/files/TrueNAS-SCALE*.iso.sha256 jenkins@staging.sys.ixsystems.net:/zdata/download.sys.truenas.net/truenas-scale-goldeye-nightly/'
+        sh 'rm -rf upload/files'
         copyArtifacts filter: '**/*.update', fingerprintArtifacts: true, flatten: true, projectName: 'Build - TrueNAS SCALE (Full - Nightly ISO)', selector: lastSuccessful(), target: 'upload/files'
         copyArtifacts filter: '**/*.json', fingerprintArtifacts: true, flatten: true, projectName: 'Build - TrueNAS SCALE (Full - Nightly ISO)', selector: lastSuccessful(), target: 'upload/files'
         sh 'ssh jenkins@staging.sys.ixsystems.net mkdir -p /zdata/update.sys.truenas.net/scale/TrueNAS-SCALE-Goldeye-Nightlies || true'

--- a/jenkins/Publish-ISO
+++ b/jenkins/Publish-ISO
@@ -34,25 +34,15 @@ pipeline {
 	    def existingReleases = readJSON text: existingReleasesContent
 	  
 	    // Add new release entry to existing releases dictionary
-	    existingReleases[manifest.version] = [
-		"profile": 'DEVELOPER',
-		"filename": manifest.filename,
-		"version": manifest.version,
-		"date": manifest.date,
-		"changelog": manifest.changelog,
-		"checksum": manifest.checksum,
-		"filesize": manifest.filesize
-	    ]
+	    // Copy all manifest fields and add profile
+	    def releaseEntry = manifest.clone()
+	    releaseEntry.profile = 'DEVELOPER'
+	    existingReleases[manifest.version] = releaseEntry
 	  
-	  // Keep only the last 30 entries by date
+	  // Keep only the last 30 entries (assuming chronological insertion order)
 	  if (existingReleases.size() > 30) {
-	    // Sort entries by date and keep only the 30 most recent
-	    def sortedEntries = existingReleases.sort { a, b -> 
-	      Date.parse("yyyy-MM-dd'T'HH:mm:ss'Z'", b.value.date).compareTo(
-		Date.parse("yyyy-MM-dd'T'HH:mm:ss'Z'", a.value.date)
-	      )
-	    }
-	    def recentEntries = sortedEntries.take(30)
+	    def entries = existingReleases.entrySet() as List
+	    def recentEntries = entries.drop(entries.size() - 30)
 	    existingReleases = [:]
 	    recentEntries.each { entry ->
 	      existingReleases[entry.key] = entry.value


### PR DESCRIPTION
In support of feature [Update Trains Tagging](https://ixsystems.atlassian.net/browse/NAS-133600)

This change adds a releases.json file with one entry per release on push of the update file, based on the manifest information for that release. The releases.json file will be kept limited to 30 packages.