### PR TITLE
NAS-136455 / 25.10 / Bring in Samba 4.22

### DIFF
--- a/conf/build.manifest
+++ b/conf/build.manifest
@@ -462,7 +462,7 @@ sources:
     - openzfs
 - name: truenas_samba
   repo: https://github.com/truenas/samba
-  branch: SCALE-v4-21-stable
+  branch: SCALE-v4-22-stable
   generate_version: false
   batch_priority: 0
   explicit_deps:


### PR DESCRIPTION
This commit switches SCALE from being built with Samba 4.21 to Samba 4.22.

https://wiki.samba.org/index.php/Samba_4.22_Features_added/changed