### PR TITLE
NAS-136593 / 25.10 / Send a final event to notify that upgrade/installation completed

### DIFF
--- a/truenas_install/__main__.py
+++ b/truenas_install/__main__.py
@@ -256,6 +256,7 @@ def main():
     input = json.loads(sys.stdin.read())
 
     old_root = input.get("old_root", None)
+    is_fresh_install = old_root is None
 
     if input.get("precheck"):
         if precheck_result := precheck(old_root):
@@ -672,6 +673,7 @@ def main():
         raise
 
     configure_system_for_zectl(pool_name)
+    write_progress(1.0, f"{'Installation' if is_fresh_install else 'Upgrade'} completed successfully")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
This PR adds changes to send a final event which notifies that installation or upgrade completed successfully - the last event scale build currently sends out is 96%, this is required for TNC to properly get notified via events about progress on the installation job.