### PR TITLE
NAS-136807 / 25.10 / Fix experimental builds

### DIFF
--- a/jenkins/Full-NoPublish
+++ b/jenkins/Full-NoPublish
@@ -33,7 +33,7 @@ pipeline {
     }
     stage('Packages') {
       steps {
-        sh 'cd src && make packages'
+        sh 'cd src && env TRUENAS_EXPERIMENTAL=n make packages'
       }
     }
     stage('Update') {

--- a/jenkins/Incremental-NoPublish
+++ b/jenkins/Incremental-NoPublish
@@ -28,7 +28,7 @@ pipeline {
     }
     stage('Packages') {
       steps {
-        sh 'cd ${BDIR} && make packages'
+        sh 'cd ${BDIR} && env TRUENAS_EXPERIMENTAL=n make packages'
       }
     }
     stage('Update') {

--- a/scale_build/config.py
+++ b/scale_build/config.py
@@ -52,7 +52,7 @@ TRY_BRANCH_OVERRIDE = get_env_variable('TRY_BRANCH_OVERRIDE', str)
 VERSION = get_env_variable('TRUENAS_VERSION', str, f'{_VERS}-{BUILD_TIME_OBJ.strftime("%Y%m%d-%H%M%S")}')
 TRUENAS_VENDOR = get_env_variable('TRUENAS_VENDOR', str)
 PRESERVE_ISO = get_env_variable('PRESERVE_ISO', bool, False)
-TRUENAS_EXPERIMENTAL = get_env_variable('TRUENAS_EXPERIMENTAL', bool, False)
+TRUENAS_EXPERIMENTAL = get_env_variable('TRUENAS_EXPERIMENTAL', bool, True)
 
 
 # We will get branch overrides and identity file path overrides from here


### PR DESCRIPTION
This will change it so that the internal server that builds the nightly images and publishes them for the public, will default to non-experimental builds instead. 