### PR TITLE
NAS-136947 / 25.10 / switch to nvidia open source driver to bring in 50-series support

### DIFF
--- a/scale_build/extensions.py
+++ b/scale_build/extensions.py
@@ -165,7 +165,16 @@ class NvidiaExtension(Extension):
     def install_nvidia_driver(self, kernel_version):
         driver = self.download_nvidia_driver()
 
-        self.run([f"/{os.path.basename(driver)}", "--skip-module-load", "--silent", f"--kernel-name={kernel_version}",
-                  "--allow-installation-with-running-driver", "--no-rebuild-initramfs"])
+        self.run(
+            [
+                f"/{os.path.basename(driver)}",
+                "--skip-module-load",
+                "--silent",
+                f"--kernel-name={kernel_version}",
+                "--allow-installation-with-running-driver",
+                "--no-rebuild-initramfs",
+                "--kernel-module-type=open"
+            ]
+        )
 
         os.unlink(driver)


### PR DESCRIPTION
When we pulled in the latest stable driver from nvidia (https://github.com/truenas/scale-build/pull/892), it was to add support for the 50-series cards. However, after a bit of testing we found that the 50-series cards require the open source variant of the driver and not the proprietary driver. Furthermore, the open source driver is the recommended driver moving forward. This switches to using the open source variant of the driver.

However, please note, this means that 10-series cards are NO LONGER SUPPORTED. This is something that we can't control. Nvidia has a statement as follows:

> After a final Game Ready Driver release in October 2025, GeForce GPUs based on Maxwell, Pascal, and Volta architectures will transition to receiving quarterly security updates for the next three years (through October 2028). Our support lifetime for these GPUs reaches up to 11 years, well beyond industry norms.