### PR TITLE
NAS-137222 / 26.04 / Bump nfs-utils to version from debian trixie

### DIFF
--- a/conf/build.manifest
+++ b/conf/build.manifest
@@ -703,7 +703,7 @@ sources:
   generate_version: false
 - name: nfs_utils
   repo: https://github.com/truenas/nfs-utils.git
-  branch: bookworm
+  branch: trixie
   generate_version: false
 
 # Nvidia extensions versions


### PR DESCRIPTION
This bumps nfs-utils from 2.6 -> 2.8 and brings in many changes and fixes.
* Fix for hostnames for HA failover
* Added mTLS support

This change will not be backported to GE.