### PR TITLE
NAS-137250 / 26.04 / Remove libvirt configuration files from mtree

### DIFF
--- a/scale_build/image/mtree.py
+++ b/scale_build/image/mtree.py
@@ -101,6 +101,8 @@ def _do_mtree_impl(mtree_file_path, version):
             '--exclude', './etc/nfs.conf.d',
             '--exclude', './etc/nut',
             '--exclude', './etc/dhcp/dhclient.conf',
+            '--exclude', './etc/libvirt',
+            '--exclude', './etc/default/libvirt-guests',
             '--exclude', './etc/pam.d/common-account',
             '--exclude', './etc/pam.d/common-auth',
             '--exclude', './etc/pam.d/common-password',


### PR DESCRIPTION
## Problem

We are not excluding libvirt files from mtree generation which results in audit check failing.

## Solution

We should exclude libvirt configurational files from mtree generation so we don't validate it as it will result in audit check failing otherwise.