### PR TITLE
NAS-137489 / 26.04 / Add truenas-pykeyring module

### DIFF
--- a/conf/build.manifest
+++ b/conf/build.manifest
@@ -107,6 +107,8 @@ base-packages:
   install_recommends: true
 - name: python3-truenas-pylibzfs
   install_recommends: true
+- name: python3-truenas-pykeyring
+  install_recommends: true
 - name: truenas-sssd
   install_recommends: true
 - name: truenas-ipaclient
@@ -460,6 +462,9 @@ sources:
   branch: master
   explicit_deps:
     - openzfs
+- name: truenas_pykeyring
+  repo: https://github.com/truenas/truenas_pykeyring
+  branch: master
 - name: truenas_samba
   repo: https://github.com/truenas/samba
   branch: SCALE-v4-22-stable


### PR DESCRIPTION
This commit adds a python extension / module to insert API key material for SCRAM auth into the kernel keyring.