### PR TITLE
NAS-137634 / 26.04 / Install restic from Debian

### DIFF
--- a/conf/build.manifest
+++ b/conf/build.manifest
@@ -177,7 +177,7 @@ base-packages:
 - name: truenas-audit-rules
   install_recommends: false
 - name: restic
-  install_recommends: true
+  install_recommends: false
 
 #
 # Packages which are removed from the base TrueNAS SCALE System by default

--- a/conf/build.manifest
+++ b/conf/build.manifest
@@ -176,6 +176,8 @@ base-packages:
   install_recommends: false
 - name: truenas-audit-rules
   install_recommends: false
+- name: restic
+  install_recommends: true
 
 #
 # Packages which are removed from the base TrueNAS SCALE System by default
@@ -676,11 +678,6 @@ sources:
   generate_version: false
 - name: rclone
   repo: https://github.com/truenas/rclone
-  branch: master
-  deoptions: nocheck
-  generate_version: false
-- name: restic
-  repo: https://github.com/truenas/restic
   branch: master
   deoptions: nocheck
   generate_version: false


### PR DESCRIPTION
This replaces our custom package at https://github.com/truenas/restic and upgrades to restic 0.18.0.