### PR TITLE
Fix dch to use dynamic distribution from build manifest

### DIFF
--- a/scale_build/packages/build.py
+++ b/scale_build/packages/build.py
@@ -8,7 +8,7 @@ from datetime import datetime
 from scale_build.config import BUILD_TIME, VERSION
 from scale_build.exceptions import CallError
 from scale_build.utils.environment import APT_ENV
-from scale_build.utils.manifest import get_truenas_train, get_release_code_name, get_secret_env
+from scale_build.utils.manifest import get_truenas_train, get_release_code_name, get_secret_env, get_manifest
 from scale_build.utils.run import run
 from scale_build.utils.paths import PKG_DIR
 
@@ -108,9 +108,11 @@ class BuildPackageMixin:
         if self.generate_version:
             generate_version_flags = f' -v {datetime.today().strftime("%Y%m%d%H%M%S")}~truenas+1 '
 
+        debian_release = get_manifest()['debian_release']
+        distribution = f'{debian_release}-truenas-unstable'
         self.run_in_chroot(
             f'cd {self.package_source} && dch -b -M {generate_version_flags}--force-distribution '
-            '--distribution bullseye-truenas-unstable \'Tagged from truenas-build\'',
+            f'--distribution {distribution} \'Tagged from truenas-build\'',
             'Failed dch changelog'
         )
 


### PR DESCRIPTION
The dch command was using hardcoded `bullseye-truenas-unstable` as the distribution when updating package changelogs. This change reads the actual Debian release from the build manifest and constructs the distribution string dynamically (e.g., `trixie-truenas-unstable` for Trixie builds), ensuring the changelog entries in built `.deb` packages reflect the correct target distribution.

**Note:** The [/usr/share/doc/ directory gets cleaned out](https://github.com/truenas/scale-build/blob/master/scale_build/image/update.py#L362) during installation (testing showed it's approximately 105 MB), most likely to save space, so this change won't be visible on running systems. However, it ensures correctness in the built .deb packages themselves.

### Testing
[With this patch](http://jenkins.eng.ixsystems.net:8080/job/master/job/custom/1577/artifact/):
```
hamza@~ $ mkdir -p ./custom-build && wget -P ./custom-build -q -c http://jenkins.eng.ixsystems.net:8080/job/master/job/custom/1577/artifact/packages/middlewared_20250929223225%7Etruenas+1_all.deb
hamza@~ $ dpkg-deb -R ./custom-build/middlewared_20250929223225~truenas+1_all.deb ./custom-build/
hamza@~ $ zcat ./custom-build/usr/share/doc/middlewared/changelog.gz | head -5
middlewared (20250929223225~truenas+1) trixie-truenas-unstable; urgency=medium

  * Tagged from truenas-build

 -- William Grzybowski <william@grzy.org>  Tue, 30 Sep 2025 02:32:25 +0000
```
[Without this patch](http://jenkins.eng.ixsystems.net:8080/job/master/job/incremental/3227/artifact/):
```
hamza@~ $ mkdir -p ./master-build && wget -P ./master-build -q -c http://jenkins.eng.ixsystems.net:8080/job/master/job/incremental/3227/artifact/packages/middlewared_20250930024947%7Etruenas+1_all.deb
hamza@~ $ dpkg-deb -R ./master-build/middlewared_20250930024947~truenas+1_all.deb ./master-build/
hamza@~ $ zcat ./master-build/usr/share/doc/middlewared/changelog.gz  | head -5
middlewared (20250930024947~truenas+1) bullseye-truenas-unstable; urgency=medium

  * Tagged from truenas-build

 -- William Grzybowski <william@grzy.org>  Tue, 30 Sep 2025 06:49:47 +0000
```