### PR TITLE
NAS-137831 / 26.04 / Remove /etc/dhcpcd.conf from mtree

### DIFF
--- a/scale_build/image/mtree.py
+++ b/scale_build/image/mtree.py
@@ -99,6 +99,7 @@ def _do_mtree_impl(mtree_file_path, version):
             '--exclude', './etc/sudoers',
             '--exclude', './etc/nfs.conf',
             '--exclude', './etc/nut',
+            '--exclude', './etc/dhcpcd.conf',
             '--exclude', './etc/dhcp/dhclient.conf',
             '--exclude', './etc/libvirt',
             '--exclude', './etc/default/libvirt-guests',


### PR DESCRIPTION
In a recent middleware PR (#[17193](https://github.com/truenas/middleware/pull/17193)) `dhcpcd.conf.mako` was added, therefore we should no longer check it.