### PR TITLE
Fix 25.10.4 build.manifest

### DIFF
--- a/conf/build.manifest
+++ b/conf/build.manifest
@@ -344,7 +344,7 @@ iso-packages:
 sources:
 - name: openssl
   repo: https://github.com/truenas/openssl
-  branch: master
+  branch: stable/goldeye
   generate_version: false
   batch_priority: 0
   predepscmd:
@@ -352,7 +352,7 @@ sources:
     - "./pull.sh"
 - name: kernel
   repo: https://github.com/truenas/linux
-  branch: truenas/linux-6.12
+  branch: stable/goldeye
   batch_priority: 0
   supports_ccache: true
   env:
@@ -400,11 +400,11 @@ sources:
         - "make -j$(nproc) bindeb-pkg"
 - name: nfs4xdr_acl_tools
   repo: https://github.com/truenas/nfs4xdr-acl-tools
-  branch: master
+  branch: stable/goldeye
 - name: openzfs
   repo: https://github.com/truenas/zfs
   batch_priority: 0
-  branch: truenas/zfs-2.3-release
+  branch: stable/goldeye
   env:
     KVERS: "$(shell apt info linux-headers-truenas-production-amd64 | awk '/Source:/ { print $$2}' | sed 's/linux-//')"
     KSRC: "/usr/src/linux-headers-truenas-production-amd64"
@@ -457,19 +457,19 @@ sources:
       generate_version: false
 - name: truenas_pylibzfs
   repo: https://github.com/truenas/truenas_pylibzfs
-  branch: master
+  branch: stable/goldeye
   explicit_deps:
     - openzfs
 - name: truenas_samba
   repo: https://github.com/truenas/samba
-  branch: SCALE-v4-22-stable
+  branch: stable/goldeye
   generate_version: false
   batch_priority: 0
   explicit_deps:
     - openzfs
 - name: truenas_sssd
   repo: https://github.com/truenas/sssd
-  branch: truenas/2.9
+  branch: stable/goldeye
   generate_version: false
   predepscmd:
     - "apt install -y wget xz-utils systemd-dev truenas-samba"
@@ -478,7 +478,7 @@ sources:
     - truenas_samba
 - name: truenas_ipaclient
   repo: https://github.com/truenas/freeipa
-  branch: main
+  branch: stable/goldeye
   generate_version: false
   predepscmd:
     - "apt install -y pkg-config truenas-samba truenas-sssd"
@@ -490,7 +490,7 @@ sources:
     - truenas_sssd
 - name: truenas_spdk
   repo: https://github.com/truenas/truenas_spdk
-  branch: master
+  branch: stable/goldeye
   generate_version: false
   predepscmd:
     - "apt install -y rsync"
@@ -502,25 +502,25 @@ sources:
     - kernel-dbg
 - name: avahi
   repo: https://github.com/truenas/avahi
-  branch: SCALE-v0.8
+  branch: stable/goldeye
   generate_version: false
 - name: py_libzfs
   repo: https://github.com/truenas/py-libzfs
-  branch: master
+  branch: stable/goldeye
   explicit_deps:
     - openzfs
 - name: zettarepl
   repo: https://github.com/truenas/zettarepl
-  branch: master
+  branch: stable/goldeye
 - name: truenas_crypto_utils
   repo: https://github.com/truenas/truenas_crypto_utils
-  branch: master
+  branch: stable/goldeye
 - name: truenas_connect_utils
   repo: https://github.com/truenas/truenas_connect_utils
-  branch: master
+  branch: stable/goldeye
 - name: truenas_installer
   repo: https://github.com/truenas/truenas-installer
-  branch: master
+  branch: stable/goldeye
 - name: scst
   repo: https://github.com/truenas/scst
   generate_version: false
@@ -537,7 +537,7 @@ sources:
   explicit_deps:
     - kernel
     - kernel-dbg
-  branch: truenas-3.10.0-pre
+  branch: stable/goldeye
   subpackages:
     - name: scst-dbg
       generate_version: false
@@ -560,7 +560,7 @@ sources:
         - kernel-dbg
 - name: truenas_binaries
   repo: https://github.com/truenas/binaries
-  branch: master
+  branch: stable/goldeye
 - name: truenas_webui
   repo: https://github.com/truenas/webui
   predepscmd:
@@ -570,23 +570,23 @@ sources:
     - "yarn install --network-timeout 100000"
     - "tar cvzf node_files.tgz node_modules/"
     - "rm -rf node_modules"
-  branch: master
+  branch: stable/goldeye
   secret_env: ["SENTRY_AUTH_TOKEN"]
 - name: sedutil
   repo: https://github.com/truenas/sedutil
-  branch: master
+  branch: stable/goldeye
 - name: python_netsnmpagent
   repo: https://github.com/truenas/python-netsnmpagent
-  branch: truenas/0.6.1
+  branch: stable/goldeye
 - name: python_truenas_requirements
   repo: https://github.com/truenas/python-truenas-requirements
-  branch: master
+  branch: stable/goldeye
 - name: licenselib
   repo: https://github.com/truenas/licenselib
-  branch: master
+  branch: stable/goldeye
 - name: zectl
   repo: https://github.com/truenas/zectl
-  branch: master
+  branch: stable/goldeye
   predepscmd:
     - "cp -a packaging/debian ."
   deps_path: packaging/debian
@@ -594,28 +594,28 @@ sources:
     - openzfs
 - name: ixdiagnose
   repo: https://github.com/truenas/ixdiagnose
-  branch: master
+  branch: stable/goldeye
 - name: ixhardware
   repo: https://github.com/truenas/ixhardware
-  branch: master
+  branch: stable/goldeye
 - name: apps_validation
   repo: https://github.com/truenas/apps_validation
-  branch: master
+  branch: stable/goldeye
 - name: py_cryptit
   repo: https://github.com/truenas/py-cryptit
-  branch: master
+  branch: stable/goldeye
 - name: py_sgio
   repo: https://github.com/truenas/py-sgio
-  branch: master
+  branch: stable/goldeye
 - name: py_fenced
   repo: https://github.com/truenas/py-fenced
-  branch: master
+  branch: stable/goldeye
 - name: py_nvme
   repo: https://github.com/truenas/py-nvme
-  branch: master
+  branch: stable/goldeye
 - name: truenas
   repo: https://github.com/truenas/middleware
-  branch: master
+  branch: stable/goldeye
   subdir: debian
   subpackages:
     - name: middlewared
@@ -629,16 +629,16 @@ sources:
       subdir: src/freenas
 - name: truenas_api_client
   repo: https://github.com/truenas/api_client
-  branch: master
+  branch: stable/goldeye
 - name: truenas_verify
   repo: https://github.com/truenas/truenas_verify
-  branch: master
+  branch: stable/goldeye
 - name: midcli
   repo: https://github.com/truenas/midcli
-  branch: master
+  branch: stable/goldeye
 - name: grub2
   repo: https://github.com/truenas/grub2
-  branch: master
+  branch: stable/goldeye
   debian_fork: true
   predepscmd:
     - "apt install -y wget xz-utils"
@@ -649,7 +649,7 @@ sources:
   batch_priority: 150
 - name: parted
   repo: https://github.com/truenas/parted
-  branch: master
+  branch: stable/goldeye
   debian_fork: true
   predepscmd:
     - "apt install -y wget xz-utils"
@@ -658,20 +658,20 @@ sources:
   generate_version: false
 - name: rclone
   repo: https://github.com/truenas/rclone
-  branch: master
+  branch: stable/goldeye
   deoptions: nocheck
   generate_version: false
 - name: restic
   repo: https://github.com/truenas/restic
-  branch: master
+  branch: stable/goldeye
   deoptions: nocheck
   generate_version: false
 - name: py_sg3
   repo: https://github.com/truenas/py-sg3
-  branch: master
+  branch: stable/goldeye
 - name: smartmontools
   repo: https://github.com/truenas/smartmontools
-  branch: master
+  branch: stable/goldeye
   debian_fork: true
   predepscmd:
     - "apt install -y wget xz-utils"
@@ -680,7 +680,7 @@ sources:
   generate_version: false
 - name: util-linux
   repo: https://github.com/truenas/util-linux
-  branch: master
+  branch: stable/goldeye
   debian_fork: true
   predepscmd:
     - "apt install -y wget xz-utils"
@@ -689,7 +689,7 @@ sources:
   generate_version: false
 - name: python3
   repo: https://github.com/truenas/python.git
-  branch: master
+  branch: stable/goldeye
   batch_priority: 0
   deoptions: nocheck
   generate_version: false
@@ -699,11 +699,11 @@ sources:
     - "tar --strip-components=1 -xvf Python-3.11.9.tar.xz"
 - name: truenas_audit_rules
   repo: https://github.com/truenas/audit_rules.git
-  branch: master
+  branch: stable/goldeye
   generate_version: false
 - name: nfs_utils
   repo: https://github.com/truenas/nfs-utils.git
-  branch: bookworm
+  branch: stable/goldeye
   generate_version: false
 
 # Nvidia extensions versions

--- a/conf/build.manifest
+++ b/conf/build.manifest
@@ -10,23 +10,23 @@ identity_file_path_default: "~/.ssh/id_rsa"
 apt-repos:
   base-url: https://apt.sys.truenas.net/
   base-url-internal: http://apt-mirror.tn.ixsystems.net/
-  url: goldeye/nightlies/debian/
+  url: goldeye/25.10.2/debian/
   distribution: bookworm
   components: main
   additional:
-  - url: goldeye/nightlies/debian-security/
+  - url: goldeye/25.10.2/debian-security/
     distribution: bookworm-security
     component: main
-  - url: goldeye/nightlies/debian-backports/
+  - url: goldeye/25.10.2/debian-backports/
     distribution: bookworm-backports
     component: "main contrib non-free non-free-firmware"
-  - url: goldeye/nightlies/debian-debug/
+  - url: goldeye/25.10.2/debian-debug/
     distribution: bookworm-debug
     component: main
-  - url: goldeye/nightlies/yarn/
+  - url: goldeye/25.10.2/yarn/
     distribution: stable
     component: main
-  - url: goldeye/nightlies/docker/
+  - url: goldeye/25.10.2/docker/
     distribution: bookworm
     component: stable
     key: keys/docker.gpg

--- a/conf/build.manifest
+++ b/conf/build.manifest
@@ -344,7 +344,7 @@ iso-packages:
 sources:
 - name: openssl
   repo: https://github.com/truenas/openssl
-  branch: stable/goldeye
+  branch: release/25.10.2
   generate_version: false
   batch_priority: 0
   predepscmd:
@@ -352,7 +352,7 @@ sources:
     - "./pull.sh"
 - name: kernel
   repo: https://github.com/truenas/linux
-  branch: stable/goldeye
+  branch: release/25.10.2
   batch_priority: 0
   supports_ccache: true
   env:
@@ -400,11 +400,11 @@ sources:
         - "make -j$(nproc) bindeb-pkg"
 - name: nfs4xdr_acl_tools
   repo: https://github.com/truenas/nfs4xdr-acl-tools
-  branch: stable/goldeye
+  branch: release/25.10.2
 - name: openzfs
   repo: https://github.com/truenas/zfs
   batch_priority: 0
-  branch: stable/goldeye
+  branch: release/25.10.2
   env:
     KVERS: "$(shell apt info linux-headers-truenas-production-amd64 | awk '/Source:/ { print $$2}' | sed 's/linux-//')"
     KSRC: "/usr/src/linux-headers-truenas-production-amd64"
@@ -457,19 +457,19 @@ sources:
       generate_version: false
 - name: truenas_pylibzfs
   repo: https://github.com/truenas/truenas_pylibzfs
-  branch: stable/goldeye
+  branch: release/25.10.2
   explicit_deps:
     - openzfs
 - name: truenas_samba
   repo: https://github.com/truenas/samba
-  branch: stable/goldeye
+  branch: release/25.10.2
   generate_version: false
   batch_priority: 0
   explicit_deps:
     - openzfs
 - name: truenas_sssd
   repo: https://github.com/truenas/sssd
-  branch: stable/goldeye
+  branch: release/25.10.2
   generate_version: false
   predepscmd:
     - "apt install -y wget xz-utils systemd-dev truenas-samba"
@@ -478,7 +478,7 @@ sources:
     - truenas_samba
 - name: truenas_ipaclient
   repo: https://github.com/truenas/freeipa
-  branch: stable/goldeye
+  branch: release/25.10.2
   generate_version: false
   predepscmd:
     - "apt install -y pkg-config truenas-samba truenas-sssd"
@@ -490,7 +490,7 @@ sources:
     - truenas_sssd
 - name: truenas_spdk
   repo: https://github.com/truenas/truenas_spdk
-  branch: stable/goldeye
+  branch: release/25.10.2
   generate_version: false
   predepscmd:
     - "apt install -y rsync"
@@ -502,25 +502,25 @@ sources:
     - kernel-dbg
 - name: avahi
   repo: https://github.com/truenas/avahi
-  branch: stable/goldeye
+  branch: release/25.10.2
   generate_version: false
 - name: py_libzfs
   repo: https://github.com/truenas/py-libzfs
-  branch: stable/goldeye
+  branch: release/25.10.2
   explicit_deps:
     - openzfs
 - name: zettarepl
   repo: https://github.com/truenas/zettarepl
-  branch: stable/goldeye
+  branch: release/25.10.2
 - name: truenas_crypto_utils
   repo: https://github.com/truenas/truenas_crypto_utils
-  branch: stable/goldeye
+  branch: release/25.10.2
 - name: truenas_connect_utils
   repo: https://github.com/truenas/truenas_connect_utils
-  branch: stable/goldeye
+  branch: release/25.10.2
 - name: truenas_installer
   repo: https://github.com/truenas/truenas-installer
-  branch: stable/goldeye
+  branch: release/25.10.2
 - name: scst
   repo: https://github.com/truenas/scst
   generate_version: false
@@ -537,7 +537,7 @@ sources:
   explicit_deps:
     - kernel
     - kernel-dbg
-  branch: stable/goldeye
+  branch: release/25.10.2
   subpackages:
     - name: scst-dbg
       generate_version: false
@@ -560,7 +560,7 @@ sources:
         - kernel-dbg
 - name: truenas_binaries
   repo: https://github.com/truenas/binaries
-  branch: stable/goldeye
+  branch: release/25.10.2
 - name: truenas_webui
   repo: https://github.com/truenas/webui
   predepscmd:
@@ -570,23 +570,23 @@ sources:
     - "yarn install --network-timeout 100000"
     - "tar cvzf node_files.tgz node_modules/"
     - "rm -rf node_modules"
-  branch: stable/goldeye
+  branch: release/25.10.2
   secret_env: ["SENTRY_AUTH_TOKEN"]
 - name: sedutil
   repo: https://github.com/truenas/sedutil
-  branch: stable/goldeye
+  branch: release/25.10.2
 - name: python_netsnmpagent
   repo: https://github.com/truenas/python-netsnmpagent
-  branch: stable/goldeye
+  branch: release/25.10.2
 - name: python_truenas_requirements
   repo: https://github.com/truenas/python-truenas-requirements
-  branch: stable/goldeye
+  branch: release/25.10.2
 - name: licenselib
   repo: https://github.com/truenas/licenselib
-  branch: stable/goldeye
+  branch: release/25.10.2
 - name: zectl
   repo: https://github.com/truenas/zectl
-  branch: stable/goldeye
+  branch: release/25.10.2
   predepscmd:
     - "cp -a packaging/debian ."
   deps_path: packaging/debian
@@ -594,28 +594,28 @@ sources:
     - openzfs
 - name: ixdiagnose
   repo: https://github.com/truenas/ixdiagnose
-  branch: stable/goldeye
+  branch: release/25.10.2
 - name: ixhardware
   repo: https://github.com/truenas/ixhardware
-  branch: stable/goldeye
+  branch: release/25.10.2
 - name: apps_validation
   repo: https://github.com/truenas/apps_validation
-  branch: stable/goldeye
+  branch: release/25.10.2
 - name: py_cryptit
   repo: https://github.com/truenas/py-cryptit
-  branch: stable/goldeye
+  branch: release/25.10.2
 - name: py_sgio
   repo: https://github.com/truenas/py-sgio
-  branch: stable/goldeye
+  branch: release/25.10.2
 - name: py_fenced
   repo: https://github.com/truenas/py-fenced
-  branch: stable/goldeye
+  branch: release/25.10.2
 - name: py_nvme
   repo: https://github.com/truenas/py-nvme
-  branch: stable/goldeye
+  branch: release/25.10.2
 - name: truenas
   repo: https://github.com/truenas/middleware
-  branch: stable/goldeye
+  branch: release/25.10.2
   subdir: debian
   subpackages:
     - name: middlewared
@@ -629,16 +629,16 @@ sources:
       subdir: src/freenas
 - name: truenas_api_client
   repo: https://github.com/truenas/api_client
-  branch: stable/goldeye
+  branch: release/25.10.2
 - name: truenas_verify
   repo: https://github.com/truenas/truenas_verify
-  branch: stable/goldeye
+  branch: release/25.10.2
 - name: midcli
   repo: https://github.com/truenas/midcli
-  branch: stable/goldeye
+  branch: release/25.10.2
 - name: grub2
   repo: https://github.com/truenas/grub2
-  branch: stable/goldeye
+  branch: release/25.10.2
   debian_fork: true
   predepscmd:
     - "apt install -y wget xz-utils"
@@ -649,7 +649,7 @@ sources:
   batch_priority: 150
 - name: parted
   repo: https://github.com/truenas/parted
-  branch: stable/goldeye
+  branch: release/25.10.2
   debian_fork: true
   predepscmd:
     - "apt install -y wget xz-utils"
@@ -658,20 +658,20 @@ sources:
   generate_version: false
 - name: rclone
   repo: https://github.com/truenas/rclone
-  branch: stable/goldeye
+  branch: release/25.10.2
   deoptions: nocheck
   generate_version: false
 - name: restic
   repo: https://github.com/truenas/restic
-  branch: stable/goldeye
+  branch: release/25.10.2
   deoptions: nocheck
   generate_version: false
 - name: py_sg3
   repo: https://github.com/truenas/py-sg3
-  branch: stable/goldeye
+  branch: release/25.10.2
 - name: smartmontools
   repo: https://github.com/truenas/smartmontools
-  branch: stable/goldeye
+  branch: release/25.10.2
   debian_fork: true
   predepscmd:
     - "apt install -y wget xz-utils"
@@ -680,7 +680,7 @@ sources:
   generate_version: false
 - name: util-linux
   repo: https://github.com/truenas/util-linux
-  branch: stable/goldeye
+  branch: release/25.10.2
   debian_fork: true
   predepscmd:
     - "apt install -y wget xz-utils"
@@ -689,7 +689,7 @@ sources:
   generate_version: false
 - name: python3
   repo: https://github.com/truenas/python.git
-  branch: stable/goldeye
+  branch: release/25.10.2
   batch_priority: 0
   deoptions: nocheck
   generate_version: false
@@ -699,11 +699,11 @@ sources:
     - "tar --strip-components=1 -xvf Python-3.11.9.tar.xz"
 - name: truenas_audit_rules
   repo: https://github.com/truenas/audit_rules.git
-  branch: stable/goldeye
+  branch: release/25.10.2
   generate_version: false
 - name: nfs_utils
   repo: https://github.com/truenas/nfs-utils.git
-  branch: stable/goldeye
+  branch: release/25.10.2
   generate_version: false
 
 # Nvidia extensions versions

--- a/conf/build.manifest
+++ b/conf/build.manifest
@@ -344,7 +344,7 @@ iso-packages:
 sources:
 - name: openssl
   repo: https://github.com/truenas/openssl
-  branch: release/25.10.2.1
+  branch: release/25.10.2.2
   generate_version: false
   batch_priority: 0
   predepscmd:
@@ -352,7 +352,7 @@ sources:
     - "./pull.sh"
 - name: kernel
   repo: https://github.com/truenas/linux
-  branch: release/25.10.2.1
+  branch: release/25.10.2.2
   batch_priority: 0
   supports_ccache: true
   env:
@@ -400,11 +400,11 @@ sources:
         - "make -j$(nproc) bindeb-pkg"
 - name: nfs4xdr_acl_tools
   repo: https://github.com/truenas/nfs4xdr-acl-tools
-  branch: release/25.10.2.1
+  branch: release/25.10.2.2
 - name: openzfs
   repo: https://github.com/truenas/zfs
   batch_priority: 0
-  branch: release/25.10.2.1
+  branch: release/25.10.2.2
   env:
     KVERS: "$(shell apt info linux-headers-truenas-production-amd64 | awk '/Source:/ { print $$2}' | sed 's/linux-//')"
     KSRC: "/usr/src/linux-headers-truenas-production-amd64"
@@ -457,19 +457,19 @@ sources:
       generate_version: false
 - name: truenas_pylibzfs
   repo: https://github.com/truenas/truenas_pylibzfs
-  branch: release/25.10.2.1
+  branch: release/25.10.2.2
   explicit_deps:
     - openzfs
 - name: truenas_samba
   repo: https://github.com/truenas/samba
-  branch: release/25.10.2.1
+  branch: release/25.10.2.2
   generate_version: false
   batch_priority: 0
   explicit_deps:
     - openzfs
 - name: truenas_sssd
   repo: https://github.com/truenas/sssd
-  branch: release/25.10.2.1
+  branch: release/25.10.2.2
   generate_version: false
   predepscmd:
     - "apt install -y wget xz-utils systemd-dev truenas-samba"
@@ -478,7 +478,7 @@ sources:
     - truenas_samba
 - name: truenas_ipaclient
   repo: https://github.com/truenas/freeipa
-  branch: release/25.10.2.1
+  branch: release/25.10.2.2
   generate_version: false
   predepscmd:
     - "apt install -y pkg-config truenas-samba truenas-sssd"
@@ -490,7 +490,7 @@ sources:
     - truenas_sssd
 - name: truenas_spdk
   repo: https://github.com/truenas/truenas_spdk
-  branch: release/25.10.2.1
+  branch: release/25.10.2.2
   generate_version: false
   predepscmd:
     - "apt install -y rsync"
@@ -502,25 +502,25 @@ sources:
     - kernel-dbg
 - name: avahi
   repo: https://github.com/truenas/avahi
-  branch: release/25.10.2.1
+  branch: release/25.10.2.2
   generate_version: false
 - name: py_libzfs
   repo: https://github.com/truenas/py-libzfs
-  branch: release/25.10.2.1
+  branch: release/25.10.2.2
   explicit_deps:
     - openzfs
 - name: zettarepl
   repo: https://github.com/truenas/zettarepl
-  branch: release/25.10.2.1
+  branch: release/25.10.2.2
 - name: truenas_crypto_utils
   repo: https://github.com/truenas/truenas_crypto_utils
-  branch: release/25.10.2.1
+  branch: release/25.10.2.2
 - name: truenas_connect_utils
   repo: https://github.com/truenas/truenas_connect_utils
-  branch: release/25.10.2.1
+  branch: release/25.10.2.2
 - name: truenas_installer
   repo: https://github.com/truenas/truenas-installer
-  branch: release/25.10.2.1
+  branch: release/25.10.2.2
 - name: scst
   repo: https://github.com/truenas/scst
   generate_version: false
@@ -537,7 +537,7 @@ sources:
   explicit_deps:
     - kernel
     - kernel-dbg
-  branch: release/25.10.2.1
+  branch: release/25.10.2.2
   subpackages:
     - name: scst-dbg
       generate_version: false
@@ -560,7 +560,7 @@ sources:
         - kernel-dbg
 - name: truenas_binaries
   repo: https://github.com/truenas/binaries
-  branch: release/25.10.2.1
+  branch: release/25.10.2.2
 - name: truenas_webui
   repo: https://github.com/truenas/webui
   predepscmd:
@@ -570,23 +570,23 @@ sources:
     - "yarn install --network-timeout 100000"
     - "tar cvzf node_files.tgz node_modules/"
     - "rm -rf node_modules"
-  branch: release/25.10.2.1
+  branch: release/25.10.2.2
   secret_env: ["SENTRY_AUTH_TOKEN"]
 - name: sedutil
   repo: https://github.com/truenas/sedutil
-  branch: release/25.10.2.1
+  branch: release/25.10.2.2
 - name: python_netsnmpagent
   repo: https://github.com/truenas/python-netsnmpagent
-  branch: release/25.10.2.1
+  branch: release/25.10.2.2
 - name: python_truenas_requirements
   repo: https://github.com/truenas/python-truenas-requirements
-  branch: release/25.10.2.1
+  branch: release/25.10.2.2
 - name: licenselib
   repo: https://github.com/truenas/licenselib
-  branch: release/25.10.2.1
+  branch: release/25.10.2.2
 - name: zectl
   repo: https://github.com/truenas/zectl
-  branch: release/25.10.2.1
+  branch: release/25.10.2.2
   predepscmd:
     - "cp -a packaging/debian ."
   deps_path: packaging/debian
@@ -594,28 +594,28 @@ sources:
     - openzfs
 - name: ixdiagnose
   repo: https://github.com/truenas/ixdiagnose
-  branch: release/25.10.2.1
+  branch: release/25.10.2.2
 - name: ixhardware
   repo: https://github.com/truenas/ixhardware
-  branch: release/25.10.2.1
+  branch: release/25.10.2.2
 - name: apps_validation
   repo: https://github.com/truenas/apps_validation
-  branch: release/25.10.2.1
+  branch: release/25.10.2.2
 - name: py_cryptit
   repo: https://github.com/truenas/py-cryptit
-  branch: release/25.10.2.1
+  branch: release/25.10.2.2
 - name: py_sgio
   repo: https://github.com/truenas/py-sgio
-  branch: release/25.10.2.1
+  branch: release/25.10.2.2
 - name: py_fenced
   repo: https://github.com/truenas/py-fenced
-  branch: release/25.10.2.1
+  branch: release/25.10.2.2
 - name: py_nvme
   repo: https://github.com/truenas/py-nvme
-  branch: release/25.10.2.1
+  branch: release/25.10.2.2
 - name: truenas
   repo: https://github.com/truenas/middleware
-  branch: release/25.10.2.1
+  branch: release/25.10.2.2
   subdir: debian
   subpackages:
     - name: middlewared
@@ -629,16 +629,16 @@ sources:
       subdir: src/freenas
 - name: truenas_api_client
   repo: https://github.com/truenas/api_client
-  branch: release/25.10.2.1
+  branch: release/25.10.2.2
 - name: truenas_verify
   repo: https://github.com/truenas/truenas_verify
-  branch: release/25.10.2.1
+  branch: release/25.10.2.2
 - name: midcli
   repo: https://github.com/truenas/midcli
-  branch: release/25.10.2.1
+  branch: release/25.10.2.2
 - name: grub2
   repo: https://github.com/truenas/grub2
-  branch: release/25.10.2.1
+  branch: release/25.10.2.2
   debian_fork: true
   predepscmd:
     - "apt install -y wget xz-utils"
@@ -649,7 +649,7 @@ sources:
   batch_priority: 150
 - name: parted
   repo: https://github.com/truenas/parted
-  branch: release/25.10.2.1
+  branch: release/25.10.2.2
   debian_fork: true
   predepscmd:
     - "apt install -y wget xz-utils"
@@ -658,20 +658,20 @@ sources:
   generate_version: false
 - name: rclone
   repo: https://github.com/truenas/rclone
-  branch: release/25.10.2.1
+  branch: release/25.10.2.2
   deoptions: nocheck
   generate_version: false
 - name: restic
   repo: https://github.com/truenas/restic
-  branch: release/25.10.2.1
+  branch: release/25.10.2.2
   deoptions: nocheck
   generate_version: false
 - name: py_sg3
   repo: https://github.com/truenas/py-sg3
-  branch: release/25.10.2.1
+  branch: release/25.10.2.2
 - name: smartmontools
   repo: https://github.com/truenas/smartmontools
-  branch: release/25.10.2.1
+  branch: release/25.10.2.2
   debian_fork: true
   predepscmd:
     - "apt install -y wget xz-utils"
@@ -680,7 +680,7 @@ sources:
   generate_version: false
 - name: util-linux
   repo: https://github.com/truenas/util-linux
-  branch: release/25.10.2.1
+  branch: release/25.10.2.2
   debian_fork: true
   predepscmd:
     - "apt install -y wget xz-utils"
@@ -689,7 +689,7 @@ sources:
   generate_version: false
 - name: python3
   repo: https://github.com/truenas/python.git
-  branch: release/25.10.2.1
+  branch: release/25.10.2.2
   batch_priority: 0
   deoptions: nocheck
   generate_version: false
@@ -699,11 +699,11 @@ sources:
     - "tar --strip-components=1 -xvf Python-3.11.9.tar.xz"
 - name: truenas_audit_rules
   repo: https://github.com/truenas/audit_rules.git
-  branch: release/25.10.2.1
+  branch: release/25.10.2.2
   generate_version: false
 - name: nfs_utils
   repo: https://github.com/truenas/nfs-utils.git
-  branch: release/25.10.2.1
+  branch: release/25.10.2.2
   generate_version: false
 
 # Nvidia extensions versions

--- a/conf/build.manifest
+++ b/conf/build.manifest
@@ -344,7 +344,7 @@ iso-packages:
 sources:
 - name: openssl
   repo: https://github.com/truenas/openssl
-  branch: release/25.10.2
+  branch: release/25.10.2.1
   generate_version: false
   batch_priority: 0
   predepscmd:
@@ -352,7 +352,7 @@ sources:
     - "./pull.sh"
 - name: kernel
   repo: https://github.com/truenas/linux
-  branch: release/25.10.2
+  branch: release/25.10.2.1
   batch_priority: 0
   supports_ccache: true
   env:
@@ -400,11 +400,11 @@ sources:
         - "make -j$(nproc) bindeb-pkg"
 - name: nfs4xdr_acl_tools
   repo: https://github.com/truenas/nfs4xdr-acl-tools
-  branch: release/25.10.2
+  branch: release/25.10.2.1
 - name: openzfs
   repo: https://github.com/truenas/zfs
   batch_priority: 0
-  branch: release/25.10.2
+  branch: release/25.10.2.1
   env:
     KVERS: "$(shell apt info linux-headers-truenas-production-amd64 | awk '/Source:/ { print $$2}' | sed 's/linux-//')"
     KSRC: "/usr/src/linux-headers-truenas-production-amd64"
@@ -457,19 +457,19 @@ sources:
       generate_version: false
 - name: truenas_pylibzfs
   repo: https://github.com/truenas/truenas_pylibzfs
-  branch: release/25.10.2
+  branch: release/25.10.2.1
   explicit_deps:
     - openzfs
 - name: truenas_samba
   repo: https://github.com/truenas/samba
-  branch: release/25.10.2
+  branch: release/25.10.2.1
   generate_version: false
   batch_priority: 0
   explicit_deps:
     - openzfs
 - name: truenas_sssd
   repo: https://github.com/truenas/sssd
-  branch: release/25.10.2
+  branch: release/25.10.2.1
   generate_version: false
   predepscmd:
     - "apt install -y wget xz-utils systemd-dev truenas-samba"
@@ -478,7 +478,7 @@ sources:
     - truenas_samba
 - name: truenas_ipaclient
   repo: https://github.com/truenas/freeipa
-  branch: release/25.10.2
+  branch: release/25.10.2.1
   generate_version: false
   predepscmd:
     - "apt install -y pkg-config truenas-samba truenas-sssd"
@@ -490,7 +490,7 @@ sources:
     - truenas_sssd
 - name: truenas_spdk
   repo: https://github.com/truenas/truenas_spdk
-  branch: release/25.10.2
+  branch: release/25.10.2.1
   generate_version: false
   predepscmd:
     - "apt install -y rsync"
@@ -502,25 +502,25 @@ sources:
     - kernel-dbg
 - name: avahi
   repo: https://github.com/truenas/avahi
-  branch: release/25.10.2
+  branch: release/25.10.2.1
   generate_version: false
 - name: py_libzfs
   repo: https://github.com/truenas/py-libzfs
-  branch: release/25.10.2
+  branch: release/25.10.2.1
   explicit_deps:
     - openzfs
 - name: zettarepl
   repo: https://github.com/truenas/zettarepl
-  branch: release/25.10.2
+  branch: release/25.10.2.1
 - name: truenas_crypto_utils
   repo: https://github.com/truenas/truenas_crypto_utils
-  branch: release/25.10.2
+  branch: release/25.10.2.1
 - name: truenas_connect_utils
   repo: https://github.com/truenas/truenas_connect_utils
-  branch: release/25.10.2
+  branch: release/25.10.2.1
 - name: truenas_installer
   repo: https://github.com/truenas/truenas-installer
-  branch: release/25.10.2
+  branch: release/25.10.2.1
 - name: scst
   repo: https://github.com/truenas/scst
   generate_version: false
@@ -537,7 +537,7 @@ sources:
   explicit_deps:
     - kernel
     - kernel-dbg
-  branch: release/25.10.2
+  branch: release/25.10.2.1
   subpackages:
     - name: scst-dbg
       generate_version: false
@@ -560,7 +560,7 @@ sources:
         - kernel-dbg
 - name: truenas_binaries
   repo: https://github.com/truenas/binaries
-  branch: release/25.10.2
+  branch: release/25.10.2.1
 - name: truenas_webui
   repo: https://github.com/truenas/webui
   predepscmd:
@@ -570,23 +570,23 @@ sources:
     - "yarn install --network-timeout 100000"
     - "tar cvzf node_files.tgz node_modules/"
     - "rm -rf node_modules"
-  branch: release/25.10.2
+  branch: release/25.10.2.1
   secret_env: ["SENTRY_AUTH_TOKEN"]
 - name: sedutil
   repo: https://github.com/truenas/sedutil
-  branch: release/25.10.2
+  branch: release/25.10.2.1
 - name: python_netsnmpagent
   repo: https://github.com/truenas/python-netsnmpagent
-  branch: release/25.10.2
+  branch: release/25.10.2.1
 - name: python_truenas_requirements
   repo: https://github.com/truenas/python-truenas-requirements
-  branch: release/25.10.2
+  branch: release/25.10.2.1
 - name: licenselib
   repo: https://github.com/truenas/licenselib
-  branch: release/25.10.2
+  branch: release/25.10.2.1
 - name: zectl
   repo: https://github.com/truenas/zectl
-  branch: release/25.10.2
+  branch: release/25.10.2.1
   predepscmd:
     - "cp -a packaging/debian ."
   deps_path: packaging/debian
@@ -594,28 +594,28 @@ sources:
     - openzfs
 - name: ixdiagnose
   repo: https://github.com/truenas/ixdiagnose
-  branch: release/25.10.2
+  branch: release/25.10.2.1
 - name: ixhardware
   repo: https://github.com/truenas/ixhardware
-  branch: release/25.10.2
+  branch: release/25.10.2.1
 - name: apps_validation
   repo: https://github.com/truenas/apps_validation
-  branch: release/25.10.2
+  branch: release/25.10.2.1
 - name: py_cryptit
   repo: https://github.com/truenas/py-cryptit
-  branch: release/25.10.2
+  branch: release/25.10.2.1
 - name: py_sgio
   repo: https://github.com/truenas/py-sgio
-  branch: release/25.10.2
+  branch: release/25.10.2.1
 - name: py_fenced
   repo: https://github.com/truenas/py-fenced
-  branch: release/25.10.2
+  branch: release/25.10.2.1
 - name: py_nvme
   repo: https://github.com/truenas/py-nvme
-  branch: release/25.10.2
+  branch: release/25.10.2.1
 - name: truenas
   repo: https://github.com/truenas/middleware
-  branch: release/25.10.2
+  branch: release/25.10.2.1
   subdir: debian
   subpackages:
     - name: middlewared
@@ -629,16 +629,16 @@ sources:
       subdir: src/freenas
 - name: truenas_api_client
   repo: https://github.com/truenas/api_client
-  branch: release/25.10.2
+  branch: release/25.10.2.1
 - name: truenas_verify
   repo: https://github.com/truenas/truenas_verify
-  branch: release/25.10.2
+  branch: release/25.10.2.1
 - name: midcli
   repo: https://github.com/truenas/midcli
-  branch: release/25.10.2
+  branch: release/25.10.2.1
 - name: grub2
   repo: https://github.com/truenas/grub2
-  branch: release/25.10.2
+  branch: release/25.10.2.1
   debian_fork: true
   predepscmd:
     - "apt install -y wget xz-utils"
@@ -649,7 +649,7 @@ sources:
   batch_priority: 150
 - name: parted
   repo: https://github.com/truenas/parted
-  branch: release/25.10.2
+  branch: release/25.10.2.1
   debian_fork: true
   predepscmd:
     - "apt install -y wget xz-utils"
@@ -658,20 +658,20 @@ sources:
   generate_version: false
 - name: rclone
   repo: https://github.com/truenas/rclone
-  branch: release/25.10.2
+  branch: release/25.10.2.1
   deoptions: nocheck
   generate_version: false
 - name: restic
   repo: https://github.com/truenas/restic
-  branch: release/25.10.2
+  branch: release/25.10.2.1
   deoptions: nocheck
   generate_version: false
 - name: py_sg3
   repo: https://github.com/truenas/py-sg3
-  branch: release/25.10.2
+  branch: release/25.10.2.1
 - name: smartmontools
   repo: https://github.com/truenas/smartmontools
-  branch: release/25.10.2
+  branch: release/25.10.2.1
   debian_fork: true
   predepscmd:
     - "apt install -y wget xz-utils"
@@ -680,7 +680,7 @@ sources:
   generate_version: false
 - name: util-linux
   repo: https://github.com/truenas/util-linux
-  branch: release/25.10.2
+  branch: release/25.10.2.1
   debian_fork: true
   predepscmd:
     - "apt install -y wget xz-utils"
@@ -689,7 +689,7 @@ sources:
   generate_version: false
 - name: python3
   repo: https://github.com/truenas/python.git
-  branch: release/25.10.2
+  branch: release/25.10.2.1
   batch_priority: 0
   deoptions: nocheck
   generate_version: false
@@ -699,11 +699,11 @@ sources:
     - "tar --strip-components=1 -xvf Python-3.11.9.tar.xz"
 - name: truenas_audit_rules
   repo: https://github.com/truenas/audit_rules.git
-  branch: release/25.10.2
+  branch: release/25.10.2.1
   generate_version: false
 - name: nfs_utils
   repo: https://github.com/truenas/nfs-utils.git
-  branch: release/25.10.2
+  branch: release/25.10.2.1
   generate_version: false
 
 # Nvidia extensions versions

--- a/conf/build.manifest
+++ b/conf/build.manifest
@@ -344,7 +344,7 @@ iso-packages:
 sources:
 - name: openssl
   repo: https://github.com/truenas/openssl
-  branch: release/25.10.2.2
+  branch: release/25.10.3
   generate_version: false
   batch_priority: 0
   predepscmd:
@@ -352,7 +352,7 @@ sources:
     - "./pull.sh"
 - name: kernel
   repo: https://github.com/truenas/linux
-  branch: release/25.10.2.2
+  branch: release/25.10.3
   batch_priority: 0
   supports_ccache: true
   env:
@@ -400,11 +400,11 @@ sources:
         - "make -j$(nproc) bindeb-pkg"
 - name: nfs4xdr_acl_tools
   repo: https://github.com/truenas/nfs4xdr-acl-tools
-  branch: release/25.10.2.2
+  branch: release/25.10.3
 - name: openzfs
   repo: https://github.com/truenas/zfs
   batch_priority: 0
-  branch: release/25.10.2.2
+  branch: release/25.10.3
   env:
     KVERS: "$(shell apt info linux-headers-truenas-production-amd64 | awk '/Source:/ { print $$2}' | sed 's/linux-//')"
     KSRC: "/usr/src/linux-headers-truenas-production-amd64"
@@ -457,19 +457,19 @@ sources:
       generate_version: false
 - name: truenas_pylibzfs
   repo: https://github.com/truenas/truenas_pylibzfs
-  branch: release/25.10.2.2
+  branch: release/25.10.3
   explicit_deps:
     - openzfs
 - name: truenas_samba
   repo: https://github.com/truenas/samba
-  branch: release/25.10.2.2
+  branch: release/25.10.3
   generate_version: false
   batch_priority: 0
   explicit_deps:
     - openzfs
 - name: truenas_sssd
   repo: https://github.com/truenas/sssd
-  branch: release/25.10.2.2
+  branch: release/25.10.3
   generate_version: false
   predepscmd:
     - "apt install -y wget xz-utils systemd-dev truenas-samba"
@@ -478,7 +478,7 @@ sources:
     - truenas_samba
 - name: truenas_ipaclient
   repo: https://github.com/truenas/freeipa
-  branch: release/25.10.2.2
+  branch: release/25.10.3
   generate_version: false
   predepscmd:
     - "apt install -y pkg-config truenas-samba truenas-sssd"
@@ -490,7 +490,7 @@ sources:
     - truenas_sssd
 - name: truenas_spdk
   repo: https://github.com/truenas/truenas_spdk
-  branch: release/25.10.2.2
+  branch: release/25.10.3
   generate_version: false
   predepscmd:
     - "apt install -y rsync"
@@ -502,25 +502,25 @@ sources:
     - kernel-dbg
 - name: avahi
   repo: https://github.com/truenas/avahi
-  branch: release/25.10.2.2
+  branch: release/25.10.3
   generate_version: false
 - name: py_libzfs
   repo: https://github.com/truenas/py-libzfs
-  branch: release/25.10.2.2
+  branch: release/25.10.3
   explicit_deps:
     - openzfs
 - name: zettarepl
   repo: https://github.com/truenas/zettarepl
-  branch: release/25.10.2.2
+  branch: release/25.10.3
 - name: truenas_crypto_utils
   repo: https://github.com/truenas/truenas_crypto_utils
-  branch: release/25.10.2.2
+  branch: release/25.10.3
 - name: truenas_connect_utils
   repo: https://github.com/truenas/truenas_connect_utils
-  branch: release/25.10.2.2
+  branch: release/25.10.3
 - name: truenas_installer
   repo: https://github.com/truenas/truenas-installer
-  branch: release/25.10.2.2
+  branch: release/25.10.3
 - name: scst
   repo: https://github.com/truenas/scst
   generate_version: false
@@ -537,7 +537,7 @@ sources:
   explicit_deps:
     - kernel
     - kernel-dbg
-  branch: release/25.10.2.2
+  branch: release/25.10.3
   subpackages:
     - name: scst-dbg
       generate_version: false
@@ -560,7 +560,7 @@ sources:
         - kernel-dbg
 - name: truenas_binaries
   repo: https://github.com/truenas/binaries
-  branch: release/25.10.2.2
+  branch: release/25.10.3
 - name: truenas_webui
   repo: https://github.com/truenas/webui
   predepscmd:
@@ -570,23 +570,23 @@ sources:
     - "yarn install --network-timeout 100000"
     - "tar cvzf node_files.tgz node_modules/"
     - "rm -rf node_modules"
-  branch: release/25.10.2.2
+  branch: release/25.10.3
   secret_env: ["SENTRY_AUTH_TOKEN"]
 - name: sedutil
   repo: https://github.com/truenas/sedutil
-  branch: release/25.10.2.2
+  branch: release/25.10.3
 - name: python_netsnmpagent
   repo: https://github.com/truenas/python-netsnmpagent
-  branch: release/25.10.2.2
+  branch: release/25.10.3
 - name: python_truenas_requirements
   repo: https://github.com/truenas/python-truenas-requirements
-  branch: release/25.10.2.2
+  branch: release/25.10.3
 - name: licenselib
   repo: https://github.com/truenas/licenselib
-  branch: release/25.10.2.2
+  branch: release/25.10.3
 - name: zectl
   repo: https://github.com/truenas/zectl
-  branch: release/25.10.2.2
+  branch: release/25.10.3
   predepscmd:
     - "cp -a packaging/debian ."
   deps_path: packaging/debian
@@ -594,28 +594,28 @@ sources:
     - openzfs
 - name: ixdiagnose
   repo: https://github.com/truenas/ixdiagnose
-  branch: release/25.10.2.2
+  branch: release/25.10.3
 - name: ixhardware
   repo: https://github.com/truenas/ixhardware
-  branch: release/25.10.2.2
+  branch: release/25.10.3
 - name: apps_validation
   repo: https://github.com/truenas/apps_validation
-  branch: release/25.10.2.2
+  branch: release/25.10.3
 - name: py_cryptit
   repo: https://github.com/truenas/py-cryptit
-  branch: release/25.10.2.2
+  branch: release/25.10.3
 - name: py_sgio
   repo: https://github.com/truenas/py-sgio
-  branch: release/25.10.2.2
+  branch: release/25.10.3
 - name: py_fenced
   repo: https://github.com/truenas/py-fenced
-  branch: release/25.10.2.2
+  branch: release/25.10.3
 - name: py_nvme
   repo: https://github.com/truenas/py-nvme
-  branch: release/25.10.2.2
+  branch: release/25.10.3
 - name: truenas
   repo: https://github.com/truenas/middleware
-  branch: release/25.10.2.2
+  branch: release/25.10.3
   subdir: debian
   subpackages:
     - name: middlewared
@@ -629,16 +629,16 @@ sources:
       subdir: src/freenas
 - name: truenas_api_client
   repo: https://github.com/truenas/api_client
-  branch: release/25.10.2.2
+  branch: release/25.10.3
 - name: truenas_verify
   repo: https://github.com/truenas/truenas_verify
-  branch: release/25.10.2.2
+  branch: release/25.10.3
 - name: midcli
   repo: https://github.com/truenas/midcli
-  branch: release/25.10.2.2
+  branch: release/25.10.3
 - name: grub2
   repo: https://github.com/truenas/grub2
-  branch: release/25.10.2.2
+  branch: release/25.10.3
   debian_fork: true
   predepscmd:
     - "apt install -y wget xz-utils"
@@ -649,7 +649,7 @@ sources:
   batch_priority: 150
 - name: parted
   repo: https://github.com/truenas/parted
-  branch: release/25.10.2.2
+  branch: release/25.10.3
   debian_fork: true
   predepscmd:
     - "apt install -y wget xz-utils"
@@ -658,20 +658,20 @@ sources:
   generate_version: false
 - name: rclone
   repo: https://github.com/truenas/rclone
-  branch: release/25.10.2.2
+  branch: release/25.10.3
   deoptions: nocheck
   generate_version: false
 - name: restic
   repo: https://github.com/truenas/restic
-  branch: release/25.10.2.2
+  branch: release/25.10.3
   deoptions: nocheck
   generate_version: false
 - name: py_sg3
   repo: https://github.com/truenas/py-sg3
-  branch: release/25.10.2.2
+  branch: release/25.10.3
 - name: smartmontools
   repo: https://github.com/truenas/smartmontools
-  branch: release/25.10.2.2
+  branch: release/25.10.3
   debian_fork: true
   predepscmd:
     - "apt install -y wget xz-utils"
@@ -680,7 +680,7 @@ sources:
   generate_version: false
 - name: util-linux
   repo: https://github.com/truenas/util-linux
-  branch: release/25.10.2.2
+  branch: release/25.10.3
   debian_fork: true
   predepscmd:
     - "apt install -y wget xz-utils"
@@ -689,7 +689,7 @@ sources:
   generate_version: false
 - name: python3
   repo: https://github.com/truenas/python.git
-  branch: release/25.10.2.2
+  branch: release/25.10.3
   batch_priority: 0
   deoptions: nocheck
   generate_version: false
@@ -699,11 +699,11 @@ sources:
     - "tar --strip-components=1 -xvf Python-3.11.9.tar.xz"
 - name: truenas_audit_rules
   repo: https://github.com/truenas/audit_rules.git
-  branch: release/25.10.2.2
+  branch: release/25.10.3
   generate_version: false
 - name: nfs_utils
   repo: https://github.com/truenas/nfs-utils.git
-  branch: release/25.10.2.2
+  branch: release/25.10.3
   generate_version: false
 
 # Nvidia extensions versions

--- a/conf/build.manifest
+++ b/conf/build.manifest
@@ -344,7 +344,7 @@ iso-packages:
 sources:
 - name: openssl
   repo: https://github.com/truenas/openssl
-  branch: release/25.10.4
+  branch: release/25.10.4.1
   generate_version: false
   batch_priority: 0
   predepscmd:
@@ -352,7 +352,7 @@ sources:
     - "./pull.sh"
 - name: kernel
   repo: https://github.com/truenas/linux
-  branch: release/25.10.4
+  branch: release/25.10.4.1
   batch_priority: 0
   supports_ccache: true
   env:
@@ -400,11 +400,11 @@ sources:
         - "make -j$(nproc) bindeb-pkg"
 - name: nfs4xdr_acl_tools
   repo: https://github.com/truenas/nfs4xdr-acl-tools
-  branch: release/25.10.4
+  branch: release/25.10.4.1
 - name: openzfs
   repo: https://github.com/truenas/zfs
   batch_priority: 0
-  branch: release/25.10.4
+  branch: release/25.10.4.1
   env:
     KVERS: "$(shell apt info linux-headers-truenas-production-amd64 | awk '/Source:/ { print $$2}' | sed 's/linux-//')"
     KSRC: "/usr/src/linux-headers-truenas-production-amd64"
@@ -457,19 +457,19 @@ sources:
       generate_version: false
 - name: truenas_pylibzfs
   repo: https://github.com/truenas/truenas_pylibzfs
-  branch: release/25.10.4
+  branch: release/25.10.4.1
   explicit_deps:
     - openzfs
 - name: truenas_samba
   repo: https://github.com/truenas/samba
-  branch: release/25.10.4
+  branch: release/25.10.4.1
   generate_version: false
   batch_priority: 0
   explicit_deps:
     - openzfs
 - name: truenas_sssd
   repo: https://github.com/truenas/sssd
-  branch: release/25.10.4
+  branch: release/25.10.4.1
   generate_version: false
   predepscmd:
     - "apt install -y wget xz-utils systemd-dev truenas-samba"
@@ -478,7 +478,7 @@ sources:
     - truenas_samba
 - name: truenas_ipaclient
   repo: https://github.com/truenas/freeipa
-  branch: release/25.10.4
+  branch: release/25.10.4.1
   generate_version: false
   predepscmd:
     - "apt install -y pkg-config truenas-samba truenas-sssd"
@@ -490,7 +490,7 @@ sources:
     - truenas_sssd
 - name: truenas_spdk
   repo: https://github.com/truenas/truenas_spdk
-  branch: release/25.10.4
+  branch: release/25.10.4.1
   generate_version: false
   predepscmd:
     - "apt install -y rsync"
@@ -502,25 +502,25 @@ sources:
     - kernel-dbg
 - name: avahi
   repo: https://github.com/truenas/avahi
-  branch: release/25.10.4
+  branch: release/25.10.4.1
   generate_version: false
 - name: py_libzfs
   repo: https://github.com/truenas/py-libzfs
-  branch: release/25.10.4
+  branch: release/25.10.4.1
   explicit_deps:
     - openzfs
 - name: zettarepl
   repo: https://github.com/truenas/zettarepl
-  branch: release/25.10.4
+  branch: release/25.10.4.1
 - name: truenas_crypto_utils
   repo: https://github.com/truenas/truenas_crypto_utils
-  branch: release/25.10.4
+  branch: release/25.10.4.1
 - name: truenas_connect_utils
   repo: https://github.com/truenas/truenas_connect_utils
-  branch: release/25.10.4
+  branch: release/25.10.4.1
 - name: truenas_installer
   repo: https://github.com/truenas/truenas-installer
-  branch: release/25.10.4
+  branch: release/25.10.4.1
 - name: scst
   repo: https://github.com/truenas/scst
   generate_version: false
@@ -537,7 +537,7 @@ sources:
   explicit_deps:
     - kernel
     - kernel-dbg
-  branch: release/25.10.4
+  branch: release/25.10.4.1
   subpackages:
     - name: scst-dbg
       generate_version: false
@@ -560,7 +560,7 @@ sources:
         - kernel-dbg
 - name: truenas_binaries
   repo: https://github.com/truenas/binaries
-  branch: release/25.10.4
+  branch: release/25.10.4.1
 - name: truenas_webui
   repo: https://github.com/truenas/webui
   predepscmd:
@@ -570,23 +570,23 @@ sources:
     - "yarn install --network-timeout 100000"
     - "tar cvzf node_files.tgz node_modules/"
     - "rm -rf node_modules"
-  branch: release/25.10.4
+  branch: release/25.10.4.1
   secret_env: ["SENTRY_AUTH_TOKEN"]
 - name: sedutil
   repo: https://github.com/truenas/sedutil
-  branch: release/25.10.4
+  branch: release/25.10.4.1
 - name: python_netsnmpagent
   repo: https://github.com/truenas/python-netsnmpagent
-  branch: release/25.10.4
+  branch: release/25.10.4.1
 - name: python_truenas_requirements
   repo: https://github.com/truenas/python-truenas-requirements
-  branch: release/25.10.4
+  branch: release/25.10.4.1
 - name: licenselib
   repo: https://github.com/truenas/licenselib
-  branch: release/25.10.4
+  branch: release/25.10.4.1
 - name: zectl
   repo: https://github.com/truenas/zectl
-  branch: release/25.10.4
+  branch: release/25.10.4.1
   predepscmd:
     - "cp -a packaging/debian ."
   deps_path: packaging/debian
@@ -594,28 +594,28 @@ sources:
     - openzfs
 - name: ixdiagnose
   repo: https://github.com/truenas/ixdiagnose
-  branch: release/25.10.4
+  branch: release/25.10.4.1
 - name: ixhardware
   repo: https://github.com/truenas/ixhardware
-  branch: release/25.10.4
+  branch: release/25.10.4.1
 - name: apps_validation
   repo: https://github.com/truenas/apps_validation
-  branch: release/25.10.4
+  branch: release/25.10.4.1
 - name: py_cryptit
   repo: https://github.com/truenas/py-cryptit
-  branch: release/25.10.4
+  branch: release/25.10.4.1
 - name: py_sgio
   repo: https://github.com/truenas/py-sgio
-  branch: release/25.10.4
+  branch: release/25.10.4.1
 - name: py_fenced
   repo: https://github.com/truenas/py-fenced
-  branch: release/25.10.4
+  branch: release/25.10.4.1
 - name: py_nvme
   repo: https://github.com/truenas/py-nvme
-  branch: release/25.10.4
+  branch: release/25.10.4.1
 - name: truenas
   repo: https://github.com/truenas/middleware
-  branch: release/25.10.4
+  branch: release/25.10.4.1
   subdir: debian
   subpackages:
     - name: middlewared
@@ -629,16 +629,16 @@ sources:
       subdir: src/freenas
 - name: truenas_api_client
   repo: https://github.com/truenas/api_client
-  branch: release/25.10.4
+  branch: release/25.10.4.1
 - name: truenas_verify
   repo: https://github.com/truenas/truenas_verify
-  branch: release/25.10.4
+  branch: release/25.10.4.1
 - name: midcli
   repo: https://github.com/truenas/midcli
-  branch: release/25.10.4
+  branch: release/25.10.4.1
 - name: grub2
   repo: https://github.com/truenas/grub2
-  branch: release/25.10.4
+  branch: release/25.10.4.1
   debian_fork: true
   predepscmd:
     - "apt install -y wget xz-utils"
@@ -649,7 +649,7 @@ sources:
   batch_priority: 150
 - name: parted
   repo: https://github.com/truenas/parted
-  branch: release/25.10.4
+  branch: release/25.10.4.1
   debian_fork: true
   predepscmd:
     - "apt install -y wget xz-utils"
@@ -658,20 +658,20 @@ sources:
   generate_version: false
 - name: rclone
   repo: https://github.com/truenas/rclone
-  branch: release/25.10.4
+  branch: release/25.10.4.1
   deoptions: nocheck
   generate_version: false
 - name: restic
   repo: https://github.com/truenas/restic
-  branch: release/25.10.4
+  branch: release/25.10.4.1
   deoptions: nocheck
   generate_version: false
 - name: py_sg3
   repo: https://github.com/truenas/py-sg3
-  branch: release/25.10.4
+  branch: release/25.10.4.1
 - name: smartmontools
   repo: https://github.com/truenas/smartmontools
-  branch: release/25.10.4
+  branch: release/25.10.4.1
   debian_fork: true
   predepscmd:
     - "apt install -y wget xz-utils"
@@ -680,7 +680,7 @@ sources:
   generate_version: false
 - name: util-linux
   repo: https://github.com/truenas/util-linux
-  branch: release/25.10.4
+  branch: release/25.10.4.1
   debian_fork: true
   predepscmd:
     - "apt install -y wget xz-utils"
@@ -689,7 +689,7 @@ sources:
   generate_version: false
 - name: python3
   repo: https://github.com/truenas/python.git
-  branch: release/25.10.4
+  branch: release/25.10.4.1
   batch_priority: 0
   deoptions: nocheck
   generate_version: false
@@ -699,11 +699,11 @@ sources:
     - "tar --strip-components=1 -xvf Python-3.11.9.tar.xz"
 - name: truenas_audit_rules
   repo: https://github.com/truenas/audit_rules.git
-  branch: release/25.10.4
+  branch: release/25.10.4.1
   generate_version: false
 - name: nfs_utils
   repo: https://github.com/truenas/nfs-utils.git
-  branch: release/25.10.4
+  branch: release/25.10.4.1
   generate_version: false
 
 # Nvidia extensions versions

--- a/conf/build.manifest
+++ b/conf/build.manifest
@@ -344,7 +344,7 @@ iso-packages:
 sources:
 - name: openssl
   repo: https://github.com/truenas/openssl
-  branch: release/25.10.4.1
+  branch: release/25.10.4
   generate_version: false
   batch_priority: 0
   predepscmd:
@@ -352,7 +352,7 @@ sources:
     - "./pull.sh"
 - name: kernel
   repo: https://github.com/truenas/linux
-  branch: release/25.10.4.1
+  branch: release/25.10.4
   batch_priority: 0
   supports_ccache: true
   env:
@@ -400,11 +400,11 @@ sources:
         - "make -j$(nproc) bindeb-pkg"
 - name: nfs4xdr_acl_tools
   repo: https://github.com/truenas/nfs4xdr-acl-tools
-  branch: release/25.10.4.1
+  branch: release/25.10.4
 - name: openzfs
   repo: https://github.com/truenas/zfs
   batch_priority: 0
-  branch: release/25.10.4.1
+  branch: release/25.10.4
   env:
     KVERS: "$(shell apt info linux-headers-truenas-production-amd64 | awk '/Source:/ { print $$2}' | sed 's/linux-//')"
     KSRC: "/usr/src/linux-headers-truenas-production-amd64"
@@ -457,19 +457,19 @@ sources:
       generate_version: false
 - name: truenas_pylibzfs
   repo: https://github.com/truenas/truenas_pylibzfs
-  branch: release/25.10.4.1
+  branch: release/25.10.4
   explicit_deps:
     - openzfs
 - name: truenas_samba
   repo: https://github.com/truenas/samba
-  branch: release/25.10.4.1
+  branch: release/25.10.4
   generate_version: false
   batch_priority: 0
   explicit_deps:
     - openzfs
 - name: truenas_sssd
   repo: https://github.com/truenas/sssd
-  branch: release/25.10.4.1
+  branch: release/25.10.4
   generate_version: false
   predepscmd:
     - "apt install -y wget xz-utils systemd-dev truenas-samba"
@@ -478,7 +478,7 @@ sources:
     - truenas_samba
 - name: truenas_ipaclient
   repo: https://github.com/truenas/freeipa
-  branch: release/25.10.4.1
+  branch: release/25.10.4
   generate_version: false
   predepscmd:
     - "apt install -y pkg-config truenas-samba truenas-sssd"
@@ -490,7 +490,7 @@ sources:
     - truenas_sssd
 - name: truenas_spdk
   repo: https://github.com/truenas/truenas_spdk
-  branch: release/25.10.4.1
+  branch: release/25.10.4
   generate_version: false
   predepscmd:
     - "apt install -y rsync"
@@ -502,25 +502,25 @@ sources:
     - kernel-dbg
 - name: avahi
   repo: https://github.com/truenas/avahi
-  branch: release/25.10.4.1
+  branch: release/25.10.4
   generate_version: false
 - name: py_libzfs
   repo: https://github.com/truenas/py-libzfs
-  branch: release/25.10.4.1
+  branch: release/25.10.4
   explicit_deps:
     - openzfs
 - name: zettarepl
   repo: https://github.com/truenas/zettarepl
-  branch: release/25.10.4.1
+  branch: release/25.10.4
 - name: truenas_crypto_utils
   repo: https://github.com/truenas/truenas_crypto_utils
-  branch: release/25.10.4.1
+  branch: release/25.10.4
 - name: truenas_connect_utils
   repo: https://github.com/truenas/truenas_connect_utils
-  branch: release/25.10.4.1
+  branch: release/25.10.4
 - name: truenas_installer
   repo: https://github.com/truenas/truenas-installer
-  branch: release/25.10.4.1
+  branch: release/25.10.4
 - name: scst
   repo: https://github.com/truenas/scst
   generate_version: false
@@ -537,7 +537,7 @@ sources:
   explicit_deps:
     - kernel
     - kernel-dbg
-  branch: release/25.10.4.1
+  branch: release/25.10.4
   subpackages:
     - name: scst-dbg
       generate_version: false
@@ -560,7 +560,7 @@ sources:
         - kernel-dbg
 - name: truenas_binaries
   repo: https://github.com/truenas/binaries
-  branch: release/25.10.4.1
+  branch: release/25.10.4
 - name: truenas_webui
   repo: https://github.com/truenas/webui
   predepscmd:
@@ -570,23 +570,23 @@ sources:
     - "yarn install --network-timeout 100000"
     - "tar cvzf node_files.tgz node_modules/"
     - "rm -rf node_modules"
-  branch: release/25.10.4.1
+  branch: release/25.10.4
   secret_env: ["SENTRY_AUTH_TOKEN"]
 - name: sedutil
   repo: https://github.com/truenas/sedutil
-  branch: release/25.10.4.1
+  branch: release/25.10.4
 - name: python_netsnmpagent
   repo: https://github.com/truenas/python-netsnmpagent
-  branch: release/25.10.4.1
+  branch: release/25.10.4
 - name: python_truenas_requirements
   repo: https://github.com/truenas/python-truenas-requirements
-  branch: release/25.10.4.1
+  branch: release/25.10.4
 - name: licenselib
   repo: https://github.com/truenas/licenselib
-  branch: release/25.10.4.1
+  branch: release/25.10.4
 - name: zectl
   repo: https://github.com/truenas/zectl
-  branch: release/25.10.4.1
+  branch: release/25.10.4
   predepscmd:
     - "cp -a packaging/debian ."
   deps_path: packaging/debian
@@ -594,28 +594,28 @@ sources:
     - openzfs
 - name: ixdiagnose
   repo: https://github.com/truenas/ixdiagnose
-  branch: release/25.10.4.1
+  branch: release/25.10.4
 - name: ixhardware
   repo: https://github.com/truenas/ixhardware
-  branch: release/25.10.4.1
+  branch: release/25.10.4
 - name: apps_validation
   repo: https://github.com/truenas/apps_validation
-  branch: release/25.10.4.1
+  branch: release/25.10.4
 - name: py_cryptit
   repo: https://github.com/truenas/py-cryptit
-  branch: release/25.10.4.1
+  branch: release/25.10.4
 - name: py_sgio
   repo: https://github.com/truenas/py-sgio
-  branch: release/25.10.4.1
+  branch: release/25.10.4
 - name: py_fenced
   repo: https://github.com/truenas/py-fenced
-  branch: release/25.10.4.1
+  branch: release/25.10.4
 - name: py_nvme
   repo: https://github.com/truenas/py-nvme
-  branch: release/25.10.4.1
+  branch: release/25.10.4
 - name: truenas
   repo: https://github.com/truenas/middleware
-  branch: release/25.10.4.1
+  branch: release/25.10.4
   subdir: debian
   subpackages:
     - name: middlewared
@@ -629,16 +629,16 @@ sources:
       subdir: src/freenas
 - name: truenas_api_client
   repo: https://github.com/truenas/api_client
-  branch: release/25.10.4.1
+  branch: release/25.10.4
 - name: truenas_verify
   repo: https://github.com/truenas/truenas_verify
-  branch: release/25.10.4.1
+  branch: release/25.10.4
 - name: midcli
   repo: https://github.com/truenas/midcli
-  branch: release/25.10.4.1
+  branch: release/25.10.4
 - name: grub2
   repo: https://github.com/truenas/grub2
-  branch: release/25.10.4.1
+  branch: release/25.10.4
   debian_fork: true
   predepscmd:
     - "apt install -y wget xz-utils"
@@ -649,7 +649,7 @@ sources:
   batch_priority: 150
 - name: parted
   repo: https://github.com/truenas/parted
-  branch: release/25.10.4.1
+  branch: release/25.10.4
   debian_fork: true
   predepscmd:
     - "apt install -y wget xz-utils"
@@ -658,20 +658,20 @@ sources:
   generate_version: false
 - name: rclone
   repo: https://github.com/truenas/rclone
-  branch: release/25.10.4.1
+  branch: release/25.10.4
   deoptions: nocheck
   generate_version: false
 - name: restic
   repo: https://github.com/truenas/restic
-  branch: release/25.10.4.1
+  branch: release/25.10.4
   deoptions: nocheck
   generate_version: false
 - name: py_sg3
   repo: https://github.com/truenas/py-sg3
-  branch: release/25.10.4.1
+  branch: release/25.10.4
 - name: smartmontools
   repo: https://github.com/truenas/smartmontools
-  branch: release/25.10.4.1
+  branch: release/25.10.4
   debian_fork: true
   predepscmd:
     - "apt install -y wget xz-utils"
@@ -680,7 +680,7 @@ sources:
   generate_version: false
 - name: util-linux
   repo: https://github.com/truenas/util-linux
-  branch: release/25.10.4.1
+  branch: release/25.10.4
   debian_fork: true
   predepscmd:
     - "apt install -y wget xz-utils"
@@ -689,7 +689,7 @@ sources:
   generate_version: false
 - name: python3
   repo: https://github.com/truenas/python.git
-  branch: release/25.10.4.1
+  branch: release/25.10.4
   batch_priority: 0
   deoptions: nocheck
   generate_version: false
@@ -699,11 +699,11 @@ sources:
     - "tar --strip-components=1 -xvf Python-3.11.9.tar.xz"
 - name: truenas_audit_rules
   repo: https://github.com/truenas/audit_rules.git
-  branch: release/25.10.4.1
+  branch: release/25.10.4
   generate_version: false
 - name: nfs_utils
   repo: https://github.com/truenas/nfs-utils.git
-  branch: release/25.10.4.1
+  branch: release/25.10.4
   generate_version: false
 
 # Nvidia extensions versions

--- a/conf/build.manifest
+++ b/conf/build.manifest
@@ -344,7 +344,7 @@ iso-packages:
 sources:
 - name: openssl
   repo: https://github.com/truenas/openssl
-  branch: release/25.10.3
+  branch: release/25.10.3.1
   generate_version: false
   batch_priority: 0
   predepscmd:
@@ -352,7 +352,7 @@ sources:
     - "./pull.sh"
 - name: kernel
   repo: https://github.com/truenas/linux
-  branch: release/25.10.3
+  branch: release/25.10.3.1
   batch_priority: 0
   supports_ccache: true
   env:
@@ -400,11 +400,11 @@ sources:
         - "make -j$(nproc) bindeb-pkg"
 - name: nfs4xdr_acl_tools
   repo: https://github.com/truenas/nfs4xdr-acl-tools
-  branch: release/25.10.3
+  branch: release/25.10.3.1
 - name: openzfs
   repo: https://github.com/truenas/zfs
   batch_priority: 0
-  branch: release/25.10.3
+  branch: release/25.10.3.1
   env:
     KVERS: "$(shell apt info linux-headers-truenas-production-amd64 | awk '/Source:/ { print $$2}' | sed 's/linux-//')"
     KSRC: "/usr/src/linux-headers-truenas-production-amd64"
@@ -457,19 +457,19 @@ sources:
       generate_version: false
 - name: truenas_pylibzfs
   repo: https://github.com/truenas/truenas_pylibzfs
-  branch: release/25.10.3
+  branch: release/25.10.3.1
   explicit_deps:
     - openzfs
 - name: truenas_samba
   repo: https://github.com/truenas/samba
-  branch: release/25.10.3
+  branch: release/25.10.3.1
   generate_version: false
   batch_priority: 0
   explicit_deps:
     - openzfs
 - name: truenas_sssd
   repo: https://github.com/truenas/sssd
-  branch: release/25.10.3
+  branch: release/25.10.3.1
   generate_version: false
   predepscmd:
     - "apt install -y wget xz-utils systemd-dev truenas-samba"
@@ -478,7 +478,7 @@ sources:
     - truenas_samba
 - name: truenas_ipaclient
   repo: https://github.com/truenas/freeipa
-  branch: release/25.10.3
+  branch: release/25.10.3.1
   generate_version: false
   predepscmd:
     - "apt install -y pkg-config truenas-samba truenas-sssd"
@@ -490,7 +490,7 @@ sources:
     - truenas_sssd
 - name: truenas_spdk
   repo: https://github.com/truenas/truenas_spdk
-  branch: release/25.10.3
+  branch: release/25.10.3.1
   generate_version: false
   predepscmd:
     - "apt install -y rsync"
@@ -502,25 +502,25 @@ sources:
     - kernel-dbg
 - name: avahi
   repo: https://github.com/truenas/avahi
-  branch: release/25.10.3
+  branch: release/25.10.3.1
   generate_version: false
 - name: py_libzfs
   repo: https://github.com/truenas/py-libzfs
-  branch: release/25.10.3
+  branch: release/25.10.3.1
   explicit_deps:
     - openzfs
 - name: zettarepl
   repo: https://github.com/truenas/zettarepl
-  branch: release/25.10.3
+  branch: release/25.10.3.1
 - name: truenas_crypto_utils
   repo: https://github.com/truenas/truenas_crypto_utils
-  branch: release/25.10.3
+  branch: release/25.10.3.1
 - name: truenas_connect_utils
   repo: https://github.com/truenas/truenas_connect_utils
-  branch: release/25.10.3
+  branch: release/25.10.3.1
 - name: truenas_installer
   repo: https://github.com/truenas/truenas-installer
-  branch: release/25.10.3
+  branch: release/25.10.3.1
 - name: scst
   repo: https://github.com/truenas/scst
   generate_version: false
@@ -537,7 +537,7 @@ sources:
   explicit_deps:
     - kernel
     - kernel-dbg
-  branch: release/25.10.3
+  branch: release/25.10.3.1
   subpackages:
     - name: scst-dbg
       generate_version: false
@@ -560,7 +560,7 @@ sources:
         - kernel-dbg
 - name: truenas_binaries
   repo: https://github.com/truenas/binaries
-  branch: release/25.10.3
+  branch: release/25.10.3.1
 - name: truenas_webui
   repo: https://github.com/truenas/webui
   predepscmd:
@@ -570,23 +570,23 @@ sources:
     - "yarn install --network-timeout 100000"
     - "tar cvzf node_files.tgz node_modules/"
     - "rm -rf node_modules"
-  branch: release/25.10.3
+  branch: release/25.10.3.1
   secret_env: ["SENTRY_AUTH_TOKEN"]
 - name: sedutil
   repo: https://github.com/truenas/sedutil
-  branch: release/25.10.3
+  branch: release/25.10.3.1
 - name: python_netsnmpagent
   repo: https://github.com/truenas/python-netsnmpagent
-  branch: release/25.10.3
+  branch: release/25.10.3.1
 - name: python_truenas_requirements
   repo: https://github.com/truenas/python-truenas-requirements
-  branch: release/25.10.3
+  branch: release/25.10.3.1
 - name: licenselib
   repo: https://github.com/truenas/licenselib
-  branch: release/25.10.3
+  branch: release/25.10.3.1
 - name: zectl
   repo: https://github.com/truenas/zectl
-  branch: release/25.10.3
+  branch: release/25.10.3.1
   predepscmd:
     - "cp -a packaging/debian ."
   deps_path: packaging/debian
@@ -594,28 +594,28 @@ sources:
     - openzfs
 - name: ixdiagnose
   repo: https://github.com/truenas/ixdiagnose
-  branch: release/25.10.3
+  branch: release/25.10.3.1
 - name: ixhardware
   repo: https://github.com/truenas/ixhardware
-  branch: release/25.10.3
+  branch: release/25.10.3.1
 - name: apps_validation
   repo: https://github.com/truenas/apps_validation
-  branch: release/25.10.3
+  branch: release/25.10.3.1
 - name: py_cryptit
   repo: https://github.com/truenas/py-cryptit
-  branch: release/25.10.3
+  branch: release/25.10.3.1
 - name: py_sgio
   repo: https://github.com/truenas/py-sgio
-  branch: release/25.10.3
+  branch: release/25.10.3.1
 - name: py_fenced
   repo: https://github.com/truenas/py-fenced
-  branch: release/25.10.3
+  branch: release/25.10.3.1
 - name: py_nvme
   repo: https://github.com/truenas/py-nvme
-  branch: release/25.10.3
+  branch: release/25.10.3.1
 - name: truenas
   repo: https://github.com/truenas/middleware
-  branch: release/25.10.3
+  branch: release/25.10.3.1
   subdir: debian
   subpackages:
     - name: middlewared
@@ -629,16 +629,16 @@ sources:
       subdir: src/freenas
 - name: truenas_api_client
   repo: https://github.com/truenas/api_client
-  branch: release/25.10.3
+  branch: release/25.10.3.1
 - name: truenas_verify
   repo: https://github.com/truenas/truenas_verify
-  branch: release/25.10.3
+  branch: release/25.10.3.1
 - name: midcli
   repo: https://github.com/truenas/midcli
-  branch: release/25.10.3
+  branch: release/25.10.3.1
 - name: grub2
   repo: https://github.com/truenas/grub2
-  branch: release/25.10.3
+  branch: release/25.10.3.1
   debian_fork: true
   predepscmd:
     - "apt install -y wget xz-utils"
@@ -649,7 +649,7 @@ sources:
   batch_priority: 150
 - name: parted
   repo: https://github.com/truenas/parted
-  branch: release/25.10.3
+  branch: release/25.10.3.1
   debian_fork: true
   predepscmd:
     - "apt install -y wget xz-utils"
@@ -658,20 +658,20 @@ sources:
   generate_version: false
 - name: rclone
   repo: https://github.com/truenas/rclone
-  branch: release/25.10.3
+  branch: release/25.10.3.1
   deoptions: nocheck
   generate_version: false
 - name: restic
   repo: https://github.com/truenas/restic
-  branch: release/25.10.3
+  branch: release/25.10.3.1
   deoptions: nocheck
   generate_version: false
 - name: py_sg3
   repo: https://github.com/truenas/py-sg3
-  branch: release/25.10.3
+  branch: release/25.10.3.1
 - name: smartmontools
   repo: https://github.com/truenas/smartmontools
-  branch: release/25.10.3
+  branch: release/25.10.3.1
   debian_fork: true
   predepscmd:
     - "apt install -y wget xz-utils"
@@ -680,7 +680,7 @@ sources:
   generate_version: false
 - name: util-linux
   repo: https://github.com/truenas/util-linux
-  branch: release/25.10.3
+  branch: release/25.10.3.1
   debian_fork: true
   predepscmd:
     - "apt install -y wget xz-utils"
@@ -689,7 +689,7 @@ sources:
   generate_version: false
 - name: python3
   repo: https://github.com/truenas/python.git
-  branch: release/25.10.3
+  branch: release/25.10.3.1
   batch_priority: 0
   deoptions: nocheck
   generate_version: false
@@ -699,11 +699,11 @@ sources:
     - "tar --strip-components=1 -xvf Python-3.11.9.tar.xz"
 - name: truenas_audit_rules
   repo: https://github.com/truenas/audit_rules.git
-  branch: release/25.10.3
+  branch: release/25.10.3.1
   generate_version: false
 - name: nfs_utils
   repo: https://github.com/truenas/nfs-utils.git
-  branch: release/25.10.3
+  branch: release/25.10.3.1
   generate_version: false
 
 # Nvidia extensions versions

--- a/conf/build.manifest
+++ b/conf/build.manifest
@@ -344,7 +344,7 @@ iso-packages:
 sources:
 - name: openssl
   repo: https://github.com/truenas/openssl
-  branch: release/25.10.3.1
+  branch: release/25.10.4
   generate_version: false
   batch_priority: 0
   predepscmd:
@@ -352,7 +352,7 @@ sources:
     - "./pull.sh"
 - name: kernel
   repo: https://github.com/truenas/linux
-  branch: release/25.10.3.1
+  branch: release/25.10.4
   batch_priority: 0
   supports_ccache: true
   env:
@@ -400,11 +400,11 @@ sources:
         - "make -j$(nproc) bindeb-pkg"
 - name: nfs4xdr_acl_tools
   repo: https://github.com/truenas/nfs4xdr-acl-tools
-  branch: release/25.10.3.1
+  branch: release/25.10.4
 - name: openzfs
   repo: https://github.com/truenas/zfs
   batch_priority: 0
-  branch: release/25.10.3.1
+  branch: release/25.10.4
   env:
     KVERS: "$(shell apt info linux-headers-truenas-production-amd64 | awk '/Source:/ { print $$2}' | sed 's/linux-//')"
     KSRC: "/usr/src/linux-headers-truenas-production-amd64"
@@ -457,19 +457,19 @@ sources:
       generate_version: false
 - name: truenas_pylibzfs
   repo: https://github.com/truenas/truenas_pylibzfs
-  branch: release/25.10.3.1
+  branch: release/25.10.4
   explicit_deps:
     - openzfs
 - name: truenas_samba
   repo: https://github.com/truenas/samba
-  branch: release/25.10.3.1
+  branch: release/25.10.4
   generate_version: false
   batch_priority: 0
   explicit_deps:
     - openzfs
 - name: truenas_sssd
   repo: https://github.com/truenas/sssd
-  branch: release/25.10.3.1
+  branch: release/25.10.4
   generate_version: false
   predepscmd:
     - "apt install -y wget xz-utils systemd-dev truenas-samba"
@@ -478,7 +478,7 @@ sources:
     - truenas_samba
 - name: truenas_ipaclient
   repo: https://github.com/truenas/freeipa
-  branch: release/25.10.3.1
+  branch: release/25.10.4
   generate_version: false
   predepscmd:
     - "apt install -y pkg-config truenas-samba truenas-sssd"
@@ -490,7 +490,7 @@ sources:
     - truenas_sssd
 - name: truenas_spdk
   repo: https://github.com/truenas/truenas_spdk
-  branch: release/25.10.3.1
+  branch: release/25.10.4
   generate_version: false
   predepscmd:
     - "apt install -y rsync"
@@ -502,25 +502,25 @@ sources:
     - kernel-dbg
 - name: avahi
   repo: https://github.com/truenas/avahi
-  branch: release/25.10.3.1
+  branch: release/25.10.4
   generate_version: false
 - name: py_libzfs
   repo: https://github.com/truenas/py-libzfs
-  branch: release/25.10.3.1
+  branch: release/25.10.4
   explicit_deps:
     - openzfs
 - name: zettarepl
   repo: https://github.com/truenas/zettarepl
-  branch: release/25.10.3.1
+  branch: release/25.10.4
 - name: truenas_crypto_utils
   repo: https://github.com/truenas/truenas_crypto_utils
-  branch: release/25.10.3.1
+  branch: release/25.10.4
 - name: truenas_connect_utils
   repo: https://github.com/truenas/truenas_connect_utils
-  branch: release/25.10.3.1
+  branch: release/25.10.4
 - name: truenas_installer
   repo: https://github.com/truenas/truenas-installer
-  branch: release/25.10.3.1
+  branch: release/25.10.4
 - name: scst
   repo: https://github.com/truenas/scst
   generate_version: false
@@ -537,7 +537,7 @@ sources:
   explicit_deps:
     - kernel
     - kernel-dbg
-  branch: release/25.10.3.1
+  branch: release/25.10.4
   subpackages:
     - name: scst-dbg
       generate_version: false
@@ -560,7 +560,7 @@ sources:
         - kernel-dbg
 - name: truenas_binaries
   repo: https://github.com/truenas/binaries
-  branch: release/25.10.3.1
+  branch: release/25.10.4
 - name: truenas_webui
   repo: https://github.com/truenas/webui
   predepscmd:
@@ -570,23 +570,23 @@ sources:
     - "yarn install --network-timeout 100000"
     - "tar cvzf node_files.tgz node_modules/"
     - "rm -rf node_modules"
-  branch: release/25.10.3.1
+  branch: release/25.10.4
   secret_env: ["SENTRY_AUTH_TOKEN"]
 - name: sedutil
   repo: https://github.com/truenas/sedutil
-  branch: release/25.10.3.1
+  branch: release/25.10.4
 - name: python_netsnmpagent
   repo: https://github.com/truenas/python-netsnmpagent
-  branch: release/25.10.3.1
+  branch: release/25.10.4
 - name: python_truenas_requirements
   repo: https://github.com/truenas/python-truenas-requirements
-  branch: release/25.10.3.1
+  branch: release/25.10.4
 - name: licenselib
   repo: https://github.com/truenas/licenselib
-  branch: release/25.10.3.1
+  branch: release/25.10.4
 - name: zectl
   repo: https://github.com/truenas/zectl
-  branch: release/25.10.3.1
+  branch: release/25.10.4
   predepscmd:
     - "cp -a packaging/debian ."
   deps_path: packaging/debian
@@ -594,28 +594,28 @@ sources:
     - openzfs
 - name: ixdiagnose
   repo: https://github.com/truenas/ixdiagnose
-  branch: release/25.10.3.1
+  branch: release/25.10.4
 - name: ixhardware
   repo: https://github.com/truenas/ixhardware
-  branch: release/25.10.3.1
+  branch: release/25.10.4
 - name: apps_validation
   repo: https://github.com/truenas/apps_validation
-  branch: release/25.10.3.1
+  branch: release/25.10.4
 - name: py_cryptit
   repo: https://github.com/truenas/py-cryptit
-  branch: release/25.10.3.1
+  branch: release/25.10.4
 - name: py_sgio
   repo: https://github.com/truenas/py-sgio
-  branch: release/25.10.3.1
+  branch: release/25.10.4
 - name: py_fenced
   repo: https://github.com/truenas/py-fenced
-  branch: release/25.10.3.1
+  branch: release/25.10.4
 - name: py_nvme
   repo: https://github.com/truenas/py-nvme
-  branch: release/25.10.3.1
+  branch: release/25.10.4
 - name: truenas
   repo: https://github.com/truenas/middleware
-  branch: release/25.10.3.1
+  branch: release/25.10.4
   subdir: debian
   subpackages:
     - name: middlewared
@@ -629,16 +629,16 @@ sources:
       subdir: src/freenas
 - name: truenas_api_client
   repo: https://github.com/truenas/api_client
-  branch: release/25.10.3.1
+  branch: release/25.10.4
 - name: truenas_verify
   repo: https://github.com/truenas/truenas_verify
-  branch: release/25.10.3.1
+  branch: release/25.10.4
 - name: midcli
   repo: https://github.com/truenas/midcli
-  branch: release/25.10.3.1
+  branch: release/25.10.4
 - name: grub2
   repo: https://github.com/truenas/grub2
-  branch: release/25.10.3.1
+  branch: release/25.10.4
   debian_fork: true
   predepscmd:
     - "apt install -y wget xz-utils"
@@ -649,7 +649,7 @@ sources:
   batch_priority: 150
 - name: parted
   repo: https://github.com/truenas/parted
-  branch: release/25.10.3.1
+  branch: release/25.10.4
   debian_fork: true
   predepscmd:
     - "apt install -y wget xz-utils"
@@ -658,20 +658,20 @@ sources:
   generate_version: false
 - name: rclone
   repo: https://github.com/truenas/rclone
-  branch: release/25.10.3.1
+  branch: release/25.10.4
   deoptions: nocheck
   generate_version: false
 - name: restic
   repo: https://github.com/truenas/restic
-  branch: release/25.10.3.1
+  branch: release/25.10.4
   deoptions: nocheck
   generate_version: false
 - name: py_sg3
   repo: https://github.com/truenas/py-sg3
-  branch: release/25.10.3.1
+  branch: release/25.10.4
 - name: smartmontools
   repo: https://github.com/truenas/smartmontools
-  branch: release/25.10.3.1
+  branch: release/25.10.4
   debian_fork: true
   predepscmd:
     - "apt install -y wget xz-utils"
@@ -680,7 +680,7 @@ sources:
   generate_version: false
 - name: util-linux
   repo: https://github.com/truenas/util-linux
-  branch: release/25.10.3.1
+  branch: release/25.10.4
   debian_fork: true
   predepscmd:
     - "apt install -y wget xz-utils"
@@ -689,7 +689,7 @@ sources:
   generate_version: false
 - name: python3
   repo: https://github.com/truenas/python.git
-  branch: release/25.10.3.1
+  branch: release/25.10.4
   batch_priority: 0
   deoptions: nocheck
   generate_version: false
@@ -699,11 +699,11 @@ sources:
     - "tar --strip-components=1 -xvf Python-3.11.9.tar.xz"
 - name: truenas_audit_rules
   repo: https://github.com/truenas/audit_rules.git
-  branch: release/25.10.3.1
+  branch: release/25.10.4
   generate_version: false
 - name: nfs_utils
   repo: https://github.com/truenas/nfs-utils.git
-  branch: release/25.10.3.1
+  branch: release/25.10.4
   generate_version: false
 
 # Nvidia extensions versions

--- a/jenkins/Full-NoPublish
+++ b/jenkins/Full-NoPublish
@@ -33,7 +33,7 @@ pipeline {
     }
     stage('Packages') {
       steps {
-        sh 'cd src && env TRUENAS_EXPERIMENTAL=n make packages'
+        sh 'cd src && make packages'
       }
     }
     stage('Update') {

--- a/jenkins/Incremental-NoPublish
+++ b/jenkins/Incremental-NoPublish
@@ -28,7 +28,7 @@ pipeline {
     }
     stage('Packages') {
       steps {
-        sh 'cd ${BDIR} && env TRUENAS_EXPERIMENTAL=n make packages'
+        sh 'cd ${BDIR} && make packages'
       }
     }
     stage('Update') {

--- a/scale_build/config.py
+++ b/scale_build/config.py
@@ -52,7 +52,6 @@ TRY_BRANCH_OVERRIDE = get_env_variable('TRY_BRANCH_OVERRIDE', str)
 VERSION = get_env_variable('TRUENAS_VERSION', str, f'{_VERS}-{BUILD_TIME_OBJ.strftime("%Y%m%d-%H%M%S")}')
 TRUENAS_VENDOR = get_env_variable('TRUENAS_VENDOR', str)
 PRESERVE_ISO = get_env_variable('PRESERVE_ISO', bool, False)
-TRUENAS_EXPERIMENTAL = get_env_variable('TRUENAS_EXPERIMENTAL', bool, True)
 
 
 # We will get branch overrides and identity file path overrides from here

--- a/scale_build/config.py
+++ b/scale_build/config.py
@@ -3,7 +3,7 @@ from time import time
 from datetime import datetime
 
 IDENTITY_FILE_PATH_OVERRIDE_SUFFIX = '_OVERRIDE_IDENTITY_FILE_PATH'
-_VERS = '25.10.0-MASTER'
+_VERS = '25.10.1-MASTER'
 
 
 def get_env_variable(key, _type, default_value=None):

--- a/scale_build/image/mtree.py
+++ b/scale_build/image/mtree.py
@@ -104,6 +104,7 @@ def _do_mtree_impl(mtree_file_path, version):
             '--exclude', './etc/libvirt',
             '--exclude', './etc/default/libvirt-guests',
             '--exclude', './etc/ssl/openssl.cnf',           # Modified by configure_fips.py
+            '--exclude', './etc/netdata/netdata.conf',
             '--exclude', './etc/pam.d/common-account',
             '--exclude', './etc/pam.d/common-auth',
             '--exclude', './etc/pam.d/common-password',

--- a/scale_build/image/mtree.py
+++ b/scale_build/image/mtree.py
@@ -101,6 +101,8 @@ def _do_mtree_impl(mtree_file_path, version):
             '--exclude', './etc/nfs.conf.d',
             '--exclude', './etc/nut',
             '--exclude', './etc/dhcp/dhclient.conf',
+            '--exclude', './etc/libvirt',
+            '--exclude', './etc/default/libvirt-guests',
             '--exclude', './etc/pam.d/common-account',
             '--exclude', './etc/pam.d/common-auth',
             '--exclude', './etc/pam.d/common-password',

--- a/scale_build/image/mtree.py
+++ b/scale_build/image/mtree.py
@@ -35,6 +35,8 @@ ETC_FILES_TO_REMOVE = [
     'etc/netdata/netdata.conf',
     'etc/nfs.conf',
     'etc/nginx/nginx.conf',
+    'etc/nvme/hostid',
+    'etc/nvme/hostnqn',
     'etc/proftpd/proftpd.conf',
     'etc/proftpd/tls.conf',
     'etc/security/limits.conf',

--- a/scale_build/image/mtree.py
+++ b/scale_build/image/mtree.py
@@ -86,11 +86,11 @@ def _do_mtree_impl(mtree_file_path, version):
             '-c', '--format=mtree',
             '--exclude', './boot/initrd.img*',
             '--exclude', './etc/aliases',
-            '--exclude', './etc/audit/audit.rules',  # TrueNAS managed and audited
+            '--exclude', './etc/audit/audit.rules',         # TrueNAS managed and audited
             '--exclude', './etc/console-setup/cached_setup_*',
             '--exclude', './etc/default/keyboard',
             '--exclude', './etc/default/kdump-tools',
-            '--exclude', './etc/default/zfs',        # Modifed in usr/local/bin/truenas-initrd.py
+            '--exclude', './etc/default/zfs',               # Modifed by truenas-initrd.py
             '--exclude', './etc/fstab',
             '--exclude', './etc/group',
             '--exclude', './etc/machine-id',
@@ -103,20 +103,24 @@ def _do_mtree_impl(mtree_file_path, version):
             '--exclude', './etc/dhcp/dhclient.conf',
             '--exclude', './etc/libvirt',
             '--exclude', './etc/default/libvirt-guests',
+            '--exclude', './etc/ssl/openssl.cnf',           # Modified by configure_fips.py
             '--exclude', './etc/pam.d/common-account',
             '--exclude', './etc/pam.d/common-auth',
             '--exclude', './etc/pam.d/common-password',
             '--exclude', './etc/pam.d/common-session',
             '--exclude', './etc/pam.d/common-session-noninteractive',
             '--exclude', './etc/pam.d/sshd',
+            '--exclude', './etc/rc?\\.d',
+            '--exclude', './etc/ssl/certs/ca-certificates.crt',
             '--exclude', './usr/lib/debug/*',
-            '--exclude', './usr/lib/debug/*',
+            '--exclude', './var/lib/ssl/fipsmodule.cnf',    # Modified by configure_fips.py
             '--exclude', './var/cache',
             '--exclude', './var/trash',
             '--exclude', './var/spool/*',
             '--exclude', './var/log/*',
             '--exclude', './var/lib/dbus/machine-id',
             '--exclude', './var/lib/certmonger/cas/*',
+            '--exclude', './var/lib/certmonger/local/*',
             '--exclude', './var/lib/smartmontools/*',
             '--options', '!all,mode,uid,gid,type,link,size,sha256',
         ]

--- a/scale_build/packages/build.py
+++ b/scale_build/packages/build.py
@@ -5,7 +5,7 @@ import shlex
 import shutil
 
 from datetime import datetime
-from scale_build.config import BUILD_TIME, VERSION, TRUENAS_EXPERIMENTAL
+from scale_build.config import BUILD_TIME, VERSION
 from scale_build.exceptions import CallError
 from scale_build.utils.environment import APT_ENV
 from scale_build.utils.manifest import get_truenas_train, get_release_code_name, get_secret_env
@@ -92,7 +92,6 @@ class BuildPackageMixin:
                     'train': get_truenas_train(),
                     'codename': get_release_code_name(),
                     'version': VERSION,
-                    'experimental': TRUENAS_EXPERIMENTAL,
                 }))
             os.makedirs(os.path.join(self.package_source_with_chroot, 'etc'), exist_ok=True)
             with open(os.path.join(self.package_source_with_chroot, 'etc/version'), 'w') as f:

--- a/truenas_install/__main__.py
+++ b/truenas_install/__main__.py
@@ -620,27 +620,27 @@ def main():
                             except Exception:
                                 pass
 
-                        if partition_1_guid == BIOS_BOOT_PARTITION_GUID:
-                            run_command([
-                                "chroot", root, "grub-install", "--target=i386-pc", f"/dev/{disk}"
-                            ])
+                            if partition_1_guid == BIOS_BOOT_PARTITION_GUID:
+                                run_command([
+                                    "chroot", root, "grub-install", "--target=i386-pc", f"/dev/{disk}"
+                                ])
 
-                        # EFI partition: position 2 (SCALE) or 1 (Core migrations)
-                        efi_partition_number = None
-                        if partition_1_guid == EFI_SYSTEM_PARTITION_GUID:
-                            efi_partition_number = 1
-                        else:
-                            try:
-                                if get_partition_guid(disk, 2) == EFI_SYSTEM_PARTITION_GUID:
-                                    efi_partition_number = 2
-                            except Exception:
-                                pass
+                            # EFI partition: position 2 (SCALE) or 1 (Core migrations)
+                            efi_partition_number = None
+                            if partition_1_guid == EFI_SYSTEM_PARTITION_GUID:
+                                efi_partition_number = 1
+                            else:
+                                try:
+                                    if get_partition_guid(disk, 2) == EFI_SYSTEM_PARTITION_GUID:
+                                        efi_partition_number = 2
+                                except Exception:
+                                    pass
 
-                        if efi_partition_number is None:
-                            continue
+                            if efi_partition_number is None:
+                                continue
 
-                        if get_partition_guid(disk, efi_partition_number) != EFI_SYSTEM_PARTITION_GUID:
-                            continue
+                            if get_partition_guid(disk, efi_partition_number) != EFI_SYSTEM_PARTITION_GUID:
+                                continue
 
                         partition = get_partition(disk, efi_partition_number)
                         run_command(["chroot", root, "mkdosfs", "-F", "32", "-s", "1", "-n", "EFI", partition])

--- a/truenas_install/__main__.py
+++ b/truenas_install/__main__.py
@@ -659,7 +659,9 @@ def main():
                             run_command(["chroot", root, "cp", "/boot/efi/EFI/debian/grubx64.efi",
                                          "/boot/efi/EFI/boot/bootx64.efi"])
 
-                            if os.path.exists("/sys/firmware/efi"):
+                            if os.path.exists("/sys/firmware/efi") and old_root is None:
+                                # Only create boot entry on fresh install.
+                                # On upgrades, the entry already exists from the original installation.
                                 run_command(["chroot", root, "efibootmgr", "-c",
                                              "-d", f"/dev/{disk}",
                                              "-p", f"{efi_partition_number}",


### PR DESCRIPTION
The 25.10.4.1 branchout was merged into wrong base branch. We've already released 25.10.4 and we're not releasing a 25.10.4.1 so no harm, no foul but this reverts the offending commit to get us back in line with reality.