### PR TITLE
Revert "branch for 25.10.4.1 (#996)"

### DIFF
--- a/conf/build.manifest
+++ b/conf/build.manifest
@@ -344,7 +344,7 @@ iso-packages:
 sources:
 - name: openssl
   repo: https://github.com/truenas/openssl
-  branch: release/25.10.4.1
+  branch: release/25.10.4
   generate_version: false
   batch_priority: 0
   predepscmd:
@@ -352,7 +352,7 @@ sources:
     - "./pull.sh"
 - name: kernel
   repo: https://github.com/truenas/linux
-  branch: release/25.10.4.1
+  branch: release/25.10.4
   batch_priority: 0
   supports_ccache: true
   env:
@@ -400,11 +400,11 @@ sources:
         - "make -j$(nproc) bindeb-pkg"
 - name: nfs4xdr_acl_tools
   repo: https://github.com/truenas/nfs4xdr-acl-tools
-  branch: release/25.10.4.1
+  branch: release/25.10.4
 - name: openzfs
   repo: https://github.com/truenas/zfs
   batch_priority: 0
-  branch: release/25.10.4.1
+  branch: release/25.10.4
   env:
     KVERS: "$(shell apt info linux-headers-truenas-production-amd64 | awk '/Source:/ { print $$2}' | sed 's/linux-//')"
     KSRC: "/usr/src/linux-headers-truenas-production-amd64"
@@ -457,19 +457,19 @@ sources:
       generate_version: false
 - name: truenas_pylibzfs
   repo: https://github.com/truenas/truenas_pylibzfs
-  branch: release/25.10.4.1
+  branch: release/25.10.4
   explicit_deps:
     - openzfs
 - name: truenas_samba
   repo: https://github.com/truenas/samba
-  branch: release/25.10.4.1
+  branch: release/25.10.4
   generate_version: false
   batch_priority: 0
   explicit_deps:
     - openzfs
 - name: truenas_sssd
   repo: https://github.com/truenas/sssd
-  branch: release/25.10.4.1
+  branch: release/25.10.4
   generate_version: false
   predepscmd:
     - "apt install -y wget xz-utils systemd-dev truenas-samba"
@@ -478,7 +478,7 @@ sources:
     - truenas_samba
 - name: truenas_ipaclient
   repo: https://github.com/truenas/freeipa
-  branch: release/25.10.4.1
+  branch: release/25.10.4
   generate_version: false
   predepscmd:
     - "apt install -y pkg-config truenas-samba truenas-sssd"
@@ -490,7 +490,7 @@ sources:
     - truenas_sssd
 - name: truenas_spdk
   repo: https://github.com/truenas/truenas_spdk
-  branch: release/25.10.4.1
+  branch: release/25.10.4
   generate_version: false
   predepscmd:
     - "apt install -y rsync"
@@ -502,25 +502,25 @@ sources:
     - kernel-dbg
 - name: avahi
   repo: https://github.com/truenas/avahi
-  branch: release/25.10.4.1
+  branch: release/25.10.4
   generate_version: false
 - name: py_libzfs
   repo: https://github.com/truenas/py-libzfs
-  branch: release/25.10.4.1
+  branch: release/25.10.4
   explicit_deps:
     - openzfs
 - name: zettarepl
   repo: https://github.com/truenas/zettarepl
-  branch: release/25.10.4.1
+  branch: release/25.10.4
 - name: truenas_crypto_utils
   repo: https://github.com/truenas/truenas_crypto_utils
-  branch: release/25.10.4.1
+  branch: release/25.10.4
 - name: truenas_connect_utils
   repo: https://github.com/truenas/truenas_connect_utils
-  branch: release/25.10.4.1
+  branch: release/25.10.4
 - name: truenas_installer
   repo: https://github.com/truenas/truenas-installer
-  branch: release/25.10.4.1
+  branch: release/25.10.4
 - name: scst
   repo: https://github.com/truenas/scst
   generate_version: false
@@ -537,7 +537,7 @@ sources:
   explicit_deps:
     - kernel
     - kernel-dbg
-  branch: release/25.10.4.1
+  branch: release/25.10.4
   subpackages:
     - name: scst-dbg
       generate_version: false
@@ -560,7 +560,7 @@ sources:
         - kernel-dbg
 - name: truenas_binaries
   repo: https://github.com/truenas/binaries
-  branch: release/25.10.4.1
+  branch: release/25.10.4
 - name: truenas_webui
   repo: https://github.com/truenas/webui
   predepscmd:
@@ -570,23 +570,23 @@ sources:
     - "yarn install --network-timeout 100000"
     - "tar cvzf node_files.tgz node_modules/"
     - "rm -rf node_modules"
-  branch: release/25.10.4.1
+  branch: release/25.10.4
   secret_env: ["SENTRY_AUTH_TOKEN"]
 - name: sedutil
   repo: https://github.com/truenas/sedutil
-  branch: release/25.10.4.1
+  branch: release/25.10.4
 - name: python_netsnmpagent
   repo: https://github.com/truenas/python-netsnmpagent
-  branch: release/25.10.4.1
+  branch: release/25.10.4
 - name: python_truenas_requirements
   repo: https://github.com/truenas/python-truenas-requirements
-  branch: release/25.10.4.1
+  branch: release/25.10.4
 - name: licenselib
   repo: https://github.com/truenas/licenselib
-  branch: release/25.10.4.1
+  branch: release/25.10.4
 - name: zectl
   repo: https://github.com/truenas/zectl
-  branch: release/25.10.4.1
+  branch: release/25.10.4
   predepscmd:
     - "cp -a packaging/debian ."
   deps_path: packaging/debian
@@ -594,28 +594,28 @@ sources:
     - openzfs
 - name: ixdiagnose
   repo: https://github.com/truenas/ixdiagnose
-  branch: release/25.10.4.1
+  branch: release/25.10.4
 - name: ixhardware
   repo: https://github.com/truenas/ixhardware
-  branch: release/25.10.4.1
+  branch: release/25.10.4
 - name: apps_validation
   repo: https://github.com/truenas/apps_validation
-  branch: release/25.10.4.1
+  branch: release/25.10.4
 - name: py_cryptit
   repo: https://github.com/truenas/py-cryptit
-  branch: release/25.10.4.1
+  branch: release/25.10.4
 - name: py_sgio
   repo: https://github.com/truenas/py-sgio
-  branch: release/25.10.4.1
+  branch: release/25.10.4
 - name: py_fenced
   repo: https://github.com/truenas/py-fenced
-  branch: release/25.10.4.1
+  branch: release/25.10.4
 - name: py_nvme
   repo: https://github.com/truenas/py-nvme
-  branch: release/25.10.4.1
+  branch: release/25.10.4
 - name: truenas
   repo: https://github.com/truenas/middleware
-  branch: release/25.10.4.1
+  branch: release/25.10.4
   subdir: debian
   subpackages:
     - name: middlewared
@@ -629,16 +629,16 @@ sources:
       subdir: src/freenas
 - name: truenas_api_client
   repo: https://github.com/truenas/api_client
-  branch: release/25.10.4.1
+  branch: release/25.10.4
 - name: truenas_verify
   repo: https://github.com/truenas/truenas_verify
-  branch: release/25.10.4.1
+  branch: release/25.10.4
 - name: midcli
   repo: https://github.com/truenas/midcli
-  branch: release/25.10.4.1
+  branch: release/25.10.4
 - name: grub2
   repo: https://github.com/truenas/grub2
-  branch: release/25.10.4.1
+  branch: release/25.10.4
   debian_fork: true
   predepscmd:
     - "apt install -y wget xz-utils"
@@ -649,7 +649,7 @@ sources:
   batch_priority: 150
 - name: parted
   repo: https://github.com/truenas/parted
-  branch: release/25.10.4.1
+  branch: release/25.10.4
   debian_fork: true
   predepscmd:
     - "apt install -y wget xz-utils"
@@ -658,20 +658,20 @@ sources:
   generate_version: false
 - name: rclone
   repo: https://github.com/truenas/rclone
-  branch: release/25.10.4.1
+  branch: release/25.10.4
   deoptions: nocheck
   generate_version: false
 - name: restic
   repo: https://github.com/truenas/restic
-  branch: release/25.10.4.1
+  branch: release/25.10.4
   deoptions: nocheck
   generate_version: false
 - name: py_sg3
   repo: https://github.com/truenas/py-sg3
-  branch: release/25.10.4.1
+  branch: release/25.10.4
 - name: smartmontools
   repo: https://github.com/truenas/smartmontools
-  branch: release/25.10.4.1
+  branch: release/25.10.4
   debian_fork: true
   predepscmd:
     - "apt install -y wget xz-utils"
@@ -680,7 +680,7 @@ sources:
   generate_version: false
 - name: util-linux
   repo: https://github.com/truenas/util-linux
-  branch: release/25.10.4.1
+  branch: release/25.10.4
   debian_fork: true
   predepscmd:
     - "apt install -y wget xz-utils"
@@ -689,7 +689,7 @@ sources:
   generate_version: false
 - name: python3
   repo: https://github.com/truenas/python.git
-  branch: release/25.10.4.1
+  branch: release/25.10.4
   batch_priority: 0
   deoptions: nocheck
   generate_version: false
@@ -699,11 +699,11 @@ sources:
     - "tar --strip-components=1 -xvf Python-3.11.9.tar.xz"
 - name: truenas_audit_rules
   repo: https://github.com/truenas/audit_rules.git
-  branch: release/25.10.4.1
+  branch: release/25.10.4
   generate_version: false
 - name: nfs_utils
   repo: https://github.com/truenas/nfs-utils.git
-  branch: release/25.10.4.1
+  branch: release/25.10.4
   generate_version: false
 
 # Nvidia extensions versions


### PR DESCRIPTION
This reverts commit eaee464e06555545438f99017bf1b1b8c3f1237a. The 25.10.4.1 branchout was merged into wrong base branch. We've already released 25.10.4 and we're not releasing a 25.10.4.1 so no harm, no foul but this reverts the offending commit to get us back in line with reality.